### PR TITLE
🧹 MPRIS: Modernize unused parameter handling with [[maybe_unused]]

### DIFF
--- a/src/mpris/DBusConnectionManager.cpp
+++ b/src/mpris/DBusConnectionManager.cpp
@@ -183,7 +183,7 @@ void DBusConnectionManager::cleanupConnection_unlocked() {
       DBusError error;
       dbus_error_init(&error);
 
-      int result =
+      [[maybe_unused]] int result =
           dbus_bus_release_name(m_connection.get(), DBUS_SERVICE_NAME, &error);
       if (dbus_error_is_set(&error)) {
         MPRIS_LOG_WARN("DBusConnectionManager",
@@ -194,7 +194,6 @@ void DBusConnectionManager::cleanupConnection_unlocked() {
         MPRIS_LOG_DEBUG("DBusConnectionManager",
                         "D-Bus service name released successfully");
       }
-      (void)result; // Suppress unused variable warning
     }
 
     // Reset the connection pointer (RAII will handle cleanup)

--- a/src/mpris/MPRISTypes.cpp
+++ b/src/mpris/MPRISTypes.cpp
@@ -92,23 +92,19 @@ bool MPRISMetadata::isEmpty() const {
 }
 
 // RAII deleters implementation
-void DBusConnectionDeleter::operator()(DBusConnection *conn) {
+void DBusConnectionDeleter::operator()([[maybe_unused]] DBusConnection *conn) {
 #ifdef HAVE_DBUS
   if (conn) {
     dbus_connection_unref(conn);
   }
-#else
-  (void)conn; // Suppress unused parameter warning
 #endif
 }
 
-void DBusMessageDeleter::operator()(DBusMessage *msg) {
+void DBusMessageDeleter::operator()([[maybe_unused]] DBusMessage *msg) {
 #ifdef HAVE_DBUS
   if (msg) {
     dbus_message_unref(msg);
   }
-#else
-  (void)msg; // Suppress unused parameter warning
 #endif
 }
 

--- a/src/mpris/MethodHandler.cpp
+++ b/src/mpris/MethodHandler.cpp
@@ -509,18 +509,15 @@ MethodHandler::handleSetPosition_unlocked(DBusConnection *connection,
 
 // Stub implementations when D-Bus is not available
 
-MethodHandler::MethodHandler(Player *player, PropertyManager *properties)
-    : m_player(player), m_properties(properties), m_initialized(false) {
-  (void)player;
-  (void)properties; // Suppress unused parameter warnings
-}
+MethodHandler::MethodHandler([[maybe_unused]] Player *player,
+                             [[maybe_unused]] PropertyManager *properties)
+    : m_player(player), m_properties(properties), m_initialized(false) {}
 
 MethodHandler::~MethodHandler() {}
 
-DBusHandlerResult MethodHandler::handleMessage(DBusConnection *connection,
-                                               DBusMessage *message) {
-  (void)connection;
-  (void)message; // Suppress unused parameter warnings
+DBusHandlerResult
+MethodHandler::handleMessage([[maybe_unused]] DBusConnection *connection,
+                             [[maybe_unused]] DBusMessage *message) {
   return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
 

--- a/src/mpris/SignalEmitter.cpp
+++ b/src/mpris/SignalEmitter.cpp
@@ -77,11 +77,9 @@ void SignalEmitter::resetStatistics() {
 // Private implementations - assume locks are already held
 
 Result<void> SignalEmitter::emitPropertiesChanged_unlocked(
-    const std::string &interface_name,
-    const std::map<std::string, DBusVariant> &changed_properties) {
+    [[maybe_unused]] const std::string &interface_name,
+    [[maybe_unused]] const std::map<std::string, DBusVariant> &changed_properties) {
 #ifndef HAVE_DBUS
-  (void)interface_name;
-  (void)changed_properties;
   return Result<void>::error("D-Bus support not compiled in");
 #else
   if (changed_properties.empty()) {
@@ -106,9 +104,8 @@ Result<void> SignalEmitter::emitPropertiesChanged_unlocked(
 #endif
 }
 
-Result<void> SignalEmitter::emitSeeked_unlocked(uint64_t position_us) {
+Result<void> SignalEmitter::emitSeeked_unlocked([[maybe_unused]] uint64_t position_us) {
 #ifndef HAVE_DBUS
-  (void)position_us;
   return Result<void>::error("D-Bus support not compiled in");
 #else
   if (!isRunning_unlocked()) {
@@ -277,11 +274,9 @@ void SignalEmitter::processBatchedSignals_unlocked() { flushBatch_unlocked(); }
 // Signal creation helpers
 
 Result<DBusMessagePtr> SignalEmitter::createPropertiesChangedMessage_unlocked(
-    const std::string &interface_name,
-    const std::map<std::string, DBusVariant> &changed_properties) {
+    [[maybe_unused]] const std::string &interface_name,
+    [[maybe_unused]] const std::map<std::string, DBusVariant> &changed_properties) {
 #ifndef HAVE_DBUS
-  (void)interface_name;
-  (void)changed_properties;
   return Result<DBusMessagePtr>::error("D-Bus support not compiled in");
 #else
   // Create PropertiesChanged signal message
@@ -455,9 +450,8 @@ Result<DBusMessagePtr> SignalEmitter::createPropertiesChangedMessage_unlocked(
 }
 
 Result<DBusMessagePtr>
-SignalEmitter::createSeekedMessage_unlocked(uint64_t position_us) {
+SignalEmitter::createSeekedMessage_unlocked([[maybe_unused]] uint64_t position_us) {
 #ifndef HAVE_DBUS
-  (void)position_us;
   return Result<DBusMessagePtr>::error("D-Bus support not compiled in");
 #else
   // Create Seeked signal message
@@ -485,9 +479,8 @@ SignalEmitter::createSeekedMessage_unlocked(uint64_t position_us) {
 
 // D-Bus message sending
 
-Result<void> SignalEmitter::sendSignalMessage_unlocked(DBusMessage *message) {
+Result<void> SignalEmitter::sendSignalMessage_unlocked([[maybe_unused]] DBusMessage *message) {
 #ifndef HAVE_DBUS
-  (void)message;
   return Result<void>::error("D-Bus support not compiled in");
 #else
   if (!message) {


### PR DESCRIPTION
🧹 MPRIS: Modernize unused parameter handling with [[maybe_unused]]

🎯 What: Replaced C-style `(void)variable;` casts with the standard C++17 `[[maybe_unused]]` attribute to suppress unused parameter and variable warnings.
💡 Why: Improves code cleanliness, maintainability, and follows modern C++ standards.
✅ Verification: Confirmed syntax correctness with a standalone C++17 compilation check and received a positive code review.
✨ Result: Cleaner and more idiomatic C++17 code across the MPRIS module.

---
*PR created automatically by Jules for task [2167849159649940927](https://jules.google.com/task/2167849159649940927) started by @segin*