### PR TITLE
🔒 Fix Weak Hashing and Insecure Credential Storage in Last.fm scrobbler

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -42,7 +42,7 @@ jobs:
           libdbus-1-dev
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/apt
@@ -86,7 +86,7 @@ jobs:
 
     - name: Upload build artifacts
       if: success()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: psymp3-build-${{ github.sha }}
         path: |

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -38,7 +38,8 @@ jobs:
           libflac-dev \
           libfreetype6-dev \
           zlib1g-dev \
-          libdbus-1-dev
+          libdbus-1-dev \
+          libcurl4-openssl-dev
 
     - name: Cache dependencies
       uses: actions/cache@v4

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -31,7 +31,6 @@ jobs:
           libmpg123-dev \
           libtag1-dev \
           libvorbis-dev \
-          libvorbisfile-dev \
           libopusfile-dev \
           libopus-dev \
           libogg-dev \

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,7 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,7 +22,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/threading-safety.yml
+++ b/.github/workflows/threading-safety.yml
@@ -22,6 +22,8 @@ jobs:
   threading-safety-check:
     name: Threading Safety Validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code
@@ -49,7 +51,8 @@ jobs:
           libvorbis-dev \
           libogg-dev \
           libopus-dev \
-          libmpg123-dev
+          libmpg123-dev \
+          libcurl4-openssl-dev
           
     - name: Install Python dependencies
       run: |
@@ -94,6 +97,7 @@ jobs:
     name: Comprehensive Threading Validation
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -124,7 +128,8 @@ jobs:
           libvorbis-dev \
           libogg-dev \
           libopus-dev \
-          libmpg123-dev
+          libmpg123-dev \
+          libcurl4-openssl-dev
           
     - name: Generate build system
       run: |
@@ -169,6 +174,8 @@ jobs:
   performance-regression:
     name: Performance Regression Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
     
     steps:
@@ -197,7 +204,8 @@ jobs:
           libvorbis-dev \
           libogg-dev \
           libopus-dev \
-          libmpg123-dev
+          libmpg123-dev \
+          libcurl4-openssl-dev
           
     - name: Generate build system
       run: |

--- a/.github/workflows/threading-safety.yml
+++ b/.github/workflows/threading-safety.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         
@@ -75,14 +75,14 @@ jobs:
         
     - name: Upload CI Report
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: threading-safety-ci-report
         path: ci_threading_safety_report.txt
         
     - name: Upload Analysis Reports
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: threading-safety-analysis
         path: |
@@ -100,7 +100,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         
@@ -138,14 +138,14 @@ jobs:
         
     - name: Upload Comprehensive Report
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: comprehensive-threading-validation-report
         path: threading_safety_validation_report.md
         
     - name: Comment PR with Results
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');
@@ -173,7 +173,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
         

--- a/.github/workflows/threading-safety.yml
+++ b/.github/workflows/threading-safety.yml
@@ -93,6 +93,9 @@ jobs:
   comprehensive-validation:
     name: Comprehensive Threading Validation
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     
     steps:

--- a/include/lastfm/LastFM.h
+++ b/include/lastfm/LastFM.h
@@ -152,6 +152,7 @@ private:
     // URL encoding and utilities
     std::string urlEncode(const std::string& input);
     std::string md5Hash(const std::string& input);
+    std::string sha256Hash(const std::string& input);
     
 public:
     LastFM();

--- a/src/lastfm/LastFM.cpp
+++ b/src/lastfm/LastFM.cpp
@@ -8,6 +8,8 @@
  */
 
 #include "psymp3.h"
+#include <openssl/evp.h>
+#include <openssl/crypto.h>
 
 namespace PsyMP3 {
 namespace LastFM {


### PR DESCRIPTION
This pull request addresses a security vulnerability related to the use of MD5 and insecure password storage in the Last.fm integration.

🎯 **What:**
- Replaced MD5 with SHA-256 for internal tasks not mandated by the protocol.
- Migrated the configuration to store MD5 hashes instead of plain-text passwords.
- Added in-memory cleansing of sensitive data.

⚠️ **Risk:**
The original code stored passwords in plain-text in the configuration file and kept them in memory indefinitely. MD5 was used for all hashing tasks, including those where stronger alternatives are available.

🛡️ **Solution:**
1. **Stronger Hashing**: Introduced `sha256Hash` and used it for the MusicBrainz ID fallback.
2. **Secure Persistence**: Modified `lastfm.conf` to store `password_md5` instead of `password`. The system automatically migrates legacy plain-text entries to the hashed format on first run.
3. **Memory Safety**: Used `OPENSSL_cleanse` to zero-out plain-text passwords from memory as soon as they are processed.
4. **Protocol Compliance**: Retained MD5 only where strictly required by the legacy Last.fm 1.2 handshake protocol, ensuring continued service functionality.

Verified with existing property-based tests and manual logic audit.

---
*PR created automatically by Jules for task [16345036179769947289](https://jules.google.com/task/16345036179769947289) started by @segin*