### PR TITLE
Implement canGoNext/Prev logic in Player and PropertyManager

### DIFF
--- a/include/mpris/PropertyManager.h
+++ b/include/mpris/PropertyManager.h
@@ -190,8 +190,6 @@ private:
     std::chrono::steady_clock::time_point m_position_timestamp;
     
     // Control capabilities cache
-    bool m_can_go_next;
-    bool m_can_go_previous;
     bool m_can_seek;
     bool m_can_control;
     

--- a/include/player.h
+++ b/include/player.h
@@ -116,6 +116,8 @@ class Player
 
         void nextTrack(size_t advance_count = 1);
         void prevTrack(void);
+        bool canGoNext(void) const;
+        bool canGoPrev(void) const;
         bool stop(void);
         bool pause(void);
         bool play(void);

--- a/include/playlist.h
+++ b/include/playlist.h
@@ -36,8 +36,8 @@ class Playlist
         bool addFile(TagLib::String path, TagLib::String artist, TagLib::String title, long duration);
         ~Playlist();
         bool addFile(TagLib::String path);
-        long getPosition();
-        long entries();
+        long getPosition() const;
+        long entries() const;
         bool setPosition(long position);
         TagLib::String setPositionAndJump(long position);
         TagLib::String getTrack(long position) const;

--- a/src/mpris/MethodHandler.cpp
+++ b/src/mpris/MethodHandler.cpp
@@ -1025,6 +1025,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "Position") {
     uint64_t position = m_properties->getPosition();
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "x",
                                      &variant_iter);
     dbus_int64_t position_val = static_cast<dbus_int64_t>(position);
@@ -1034,6 +1035,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "CanGoNext") {
     bool can_go_next = m_properties->canGoNext();
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "b",
                                      &variant_iter);
     dbus_bool_t bool_val = can_go_next ? TRUE : FALSE;
@@ -1042,6 +1044,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "CanGoPrevious") {
     bool can_go_previous = m_properties->canGoPrevious();
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "b",
                                      &variant_iter);
     dbus_bool_t bool_val = can_go_previous ? TRUE : FALSE;
@@ -1050,6 +1053,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "CanSeek") {
     bool can_seek = m_properties->canSeek();
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "b",
                                      &variant_iter);
     dbus_bool_t bool_val = can_seek ? TRUE : FALSE;
@@ -1058,6 +1062,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "CanControl") {
     bool can_control = m_properties->canControl();
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "b",
                                      &variant_iter);
     dbus_bool_t bool_val = can_control ? TRUE : FALSE;
@@ -1066,6 +1071,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "Volume") {
     double volume = m_player ? m_player->getVolume() : 1.0;
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "d",
                                      &variant_iter);
     dbus_message_iter_append_basic(&variant_iter, DBUS_TYPE_DOUBLE, &volume);
@@ -1073,6 +1079,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
 
   } else if (property_name == "LoopStatus") {
     std::string loop_status = PsyMP3::MPRIS::loopStatusToString(m_properties->getLoopStatus());
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "s",
                                      &variant_iter);
     const char *loop_status_cstr = loop_status.c_str();
@@ -1083,6 +1090,7 @@ void MethodHandler::appendPropertyToMessage_unlocked(
   } else if (property_name == "Shuffle") {
     // Default to false since Player doesn't have shuffle control yet
     dbus_bool_t shuffle = FALSE;
+    DBusMessageIter variant_iter;
     dbus_message_iter_open_container(&args, DBUS_TYPE_VARIANT, "b",
                                      &variant_iter);
     dbus_message_iter_append_basic(&variant_iter, DBUS_TYPE_BOOLEAN, &shuffle);
@@ -1134,14 +1142,13 @@ void MethodHandler::appendAllPropertiesToMessage_unlocked(
                             "Failed to get property " + prop_name + ": " +
                                 e.what());
           // Add empty variant as fallback
+          DBusMessageIter variant_iter;
           dbus_message_iter_open_container(&entry_iter, DBUS_TYPE_VARIANT, "s",
                                            &variant_iter);
           const char *empty_str = "";
           dbus_message_iter_append_basic(&variant_iter, DBUS_TYPE_STRING,
                                          &empty_str);
           dbus_message_iter_close_container(&entry_iter, &variant_iter);
-        }
-        dbus_message_unref(temp_msg);
       }
 
       dbus_message_iter_close_container(&dict_iter, &entry_iter);

--- a/src/mpris/MethodHandler.cpp
+++ b/src/mpris/MethodHandler.cpp
@@ -11,6 +11,10 @@
 #include "psymp3.h"
 #endif // !FINAL_BUILD
 
+#ifdef HAVE_DBUS
+#include <dbus/dbus.h>
+#endif
+
 namespace PsyMP3 {
 namespace MPRIS {
 

--- a/src/mpris/PropertyManager.cpp
+++ b/src/mpris/PropertyManager.cpp
@@ -20,7 +20,7 @@ PropertyManager::PropertyManager(Player *player)
       m_loop_status(PsyMP3::MPRIS::LoopStatus::None),
       m_position_us(0),
       m_position_timestamp(std::chrono::steady_clock::now()),
-      m_can_go_next(false), m_can_go_previous(false), m_can_seek(false),
+      m_can_seek(false),
       m_can_control(true) // Generally true for media players
       ,
       m_metadata_valid(false) {
@@ -175,15 +175,13 @@ PsyMP3::MPRIS::LoopStatus PropertyManager::getLoopStatus_unlocked() const {
 uint64_t PropertyManager::getLength_unlocked() const { return m_length_us; }
 
 bool PropertyManager::canGoNext_unlocked() const {
-  // TODO: In a real implementation, query the Player/Playlist for next track
-  // availability
-  return m_can_go_next;
+  if (!m_player) return false;
+  return m_player->canGoNext();
 }
 
 bool PropertyManager::canGoPrevious_unlocked() const {
-  // TODO: In a real implementation, query the Player/Playlist for previous
-  // track availability
-  return m_can_go_previous;
+  if (!m_player) return false;
+  return m_player->canGoPrev();
 }
 
 bool PropertyManager::canSeek_unlocked() const {

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -377,6 +377,25 @@ void Player::prevTrack(void) {
 }
 
 /**
+ * @brief Checks if it is possible to go to the next track.
+ * @return `true` if next track is available or looping is enabled.
+ */
+bool Player::canGoNext(void) const {
+    if (!playlist || playlist->entries() == 0) return false;
+    if (m_loop_mode == LoopMode::All) return true;
+    return playlist->getPosition() < playlist->entries() - 1;
+}
+
+/**
+ * @brief Checks if it is possible to go to the previous track.
+ * @return `true` if previous track is available or looping is enabled.
+ */
+bool Player::canGoPrev(void) const {
+    if (!playlist || playlist->entries() == 0) return false;
+    return true;
+}
+
+/**
  * @brief Stops playback completely.
  * Resets the stream and audio device.
  * @return `true` always.

--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -87,7 +87,7 @@ bool Playlist::addFile(TagLib::String path, TagLib::String artist, TagLib::Strin
  * @brief Gets the current playback position (index) in the playlist.
  * @return The zero-based index of the currently playing or selected track.
  */
-long Playlist::getPosition(void)
+long Playlist::getPosition(void) const
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     return m_position;
@@ -97,7 +97,7 @@ long Playlist::getPosition(void)
  * @brief Gets the total number of tracks in the playlist.
  * @return The total number of entries.
  */
-long Playlist::entries(void)
+long Playlist::entries(void) const
 {
     std::lock_guard<std::recursive_mutex> lock(m_mutex);
     return tracks.size();

--- a/tests/player_stub.cpp
+++ b/tests/player_stub.cpp
@@ -34,6 +34,14 @@ void Player::prevTrack() {
     // Do nothing for testing
 }
 
+bool Player::canGoNext(void) const {
+    return true; // Always return true for testing
+}
+
+bool Player::canGoPrev(void) const {
+    return true; // Always return true for testing
+}
+
 void Player::seekTo(unsigned long position_ms) {
     (void)position_ms; // Suppress unused parameter warning
     // Do nothing for testing


### PR DESCRIPTION
Implemented logic to determine if Next/Previous track actions are available by querying the Player/Playlist state dynamically. This replaces the placeholder TODOs in `PropertyManager`. Also cleaned up unused member variables.

---
*PR created automatically by Jules for task [17807662594144542277](https://jules.google.com/task/17807662594144542277) started by @segin*