### PR TITLE
Fix MethodHandler syntax error to enable correct MPRIS Metadata serialization

### DIFF
--- a/src/mpris/MethodHandler.cpp
+++ b/src/mpris/MethodHandler.cpp
@@ -1013,6 +1013,7 @@ void MethodHandler::appendVariantToIter_unlocked(
 void MethodHandler::appendPropertyToMessage_unlocked(
     DBusMessage *reply, const std::string &property_name) {
   DBusMessageIter args;
+  DBusMessageIter variant_iter;
   dbus_message_iter_init_append(reply, &args);
 
   if (property_name == "PlaybackStatus") {

--- a/src/mpris/MethodHandler.cpp
+++ b/src/mpris/MethodHandler.cpp
@@ -1141,8 +1141,6 @@ void MethodHandler::appendAllPropertiesToMessage_unlocked(
                                          &empty_str);
           dbus_message_iter_close_container(&entry_iter, &variant_iter);
         }
-        dbus_message_unref(temp_msg);
-      }
 
       dbus_message_iter_close_container(&dict_iter, &entry_iter);
     }


### PR DESCRIPTION
The task was to handle "dict-in-dict" properly for MPRIS Metadata in `PropertyManager.cpp`.
Upon investigation, `PropertyManager.cpp` was found to already contain the correct logic: it passes a `std::map<std::string, DBusVariant>` (which is `DBusDictionary`) to the `DBusVariant` constructor, matching the MPRIS specification for `Metadata` (type `a{sv}`).

However, a related bug was found in `src/mpris/MethodHandler.cpp` within the `appendAllPropertiesToMessage_unlocked` function, which is responsible for serializing these properties (including Metadata). The bug consisted of an undefined variable usage (`temp_msg`) and a misplaced closing brace that would prevent compilation and correct execution of property retrieval.

This change fixes the syntax error in `MethodHandler.cpp` to ensure the correct `PropertyManager` logic can actually be used.

Verification:
- Created a standalone reproduction script `reproduce_issue.cpp` (using `FINAL_BUILD` to mock dependencies) which confirmed that `PropertyManager::getAllProperties` correctly returns a `DBusVariant` of type `Dictionary` for the "Metadata" key.
- Visually verified the fix in `MethodHandler.cpp` to ensure loop structure is restored and invalid code is removed.

---
*PR created automatically by Jules for task [13964806078296396451](https://jules.google.com/task/13964806078296396451) started by @segin*