### PR TITLE
Add title text rendering to WindowFrameWidget

### DIFF
--- a/include/widget/windowing/WindowFrameWidget.h
+++ b/include/widget/windowing/WindowFrameWidget.h
@@ -26,6 +26,8 @@
 
 // No direct includes - all includes should be in psymp3.h
 
+class Font;
+
 namespace PsyMP3 {
 namespace Widget {
 namespace Windowing {
@@ -43,8 +45,9 @@ public:
      * @param client_width Width of the client area
      * @param client_height Height of the client area
      * @param title Window title displayed in the titlebar
+     * @param font Font used for the titlebar text
      */
-    WindowFrameWidget(int client_width, int client_height, const std::string& title = "");
+    WindowFrameWidget(int client_width, int client_height, const std::string& title = "", Font* font = nullptr);
     
     /**
      * @brief Sets whether the window is resizable.
@@ -241,6 +244,7 @@ private:
     static constexpr int TRIANGLE_SIZE = 3;
     
     std::string m_title;
+    Font* m_font;
     int m_client_width;
     int m_client_height;
     

--- a/include/widget/windowing/WindowWidget.h
+++ b/include/widget/windowing/WindowWidget.h
@@ -26,6 +26,8 @@
 
 // No direct includes - all includes should be in psymp3.h
 
+class Font;
+
 namespace PsyMP3 {
 namespace Widget {
 namespace Windowing {
@@ -84,8 +86,9 @@ public:
      * @param client_width Width of the client area (content area)
      * @param client_height Height of the client area (content area)
      * @param title Window title displayed in the titlebar
+     * @param font Font used for the titlebar text
      */
-    WindowWidget(int client_width, int client_height, const std::string& title = "");
+    WindowWidget(int client_width, int client_height, const std::string& title = "", Font* font = nullptr);
     
     /**
      * @brief Virtual destructor.

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -1960,7 +1960,7 @@ void Player::toggleTestWindowH()
         showToast("Test Window H: Closed");
     } else {
         // Open the window (client area is 160x120)
-        m_test_window_h = std::make_unique<WindowFrameWidget>(160, 120, "Test Window H");
+        m_test_window_h = std::make_unique<WindowFrameWidget>(160, 120, "Test Window H", font.get());
         
         // Only set position, keep the calculated size from constructor
         Rect calculated_size = m_test_window_h->getPos();
@@ -2018,7 +2018,7 @@ void Player::toggleTestWindowB()
         showToast("Test Window B: Closed");
     } else {
         // Open the window (client area is 160x60)
-        m_test_window_b = std::make_unique<WindowFrameWidget>(160, 60, "Test Window B");
+        m_test_window_b = std::make_unique<WindowFrameWidget>(160, 60, "Test Window B", font.get());
         m_test_window_b->setResizable(false); // Make window B non-resizable (triggers refresh)
         
         // Only set position, keep the calculated size from setResizable(false)
@@ -2075,7 +2075,7 @@ void Player::createRandomWindows()
         
         // Create WindowFrameWidget directly like H and B windows
         std::string title = "Random Window " + std::to_string(++m_random_window_counter);
-        auto window = std::make_unique<WindowFrameWidget>(client_width, client_height, title);
+        auto window = std::make_unique<WindowFrameWidget>(client_width, client_height, title, font.get());
         window->setPos(Rect(x, y, client_width + 8, client_height + 27)); // Include frame borders
         
         // Set up callbacks using the WindowFrameWidget system like H/B windows

--- a/src/widget/windowing/WindowFrameWidget.cpp
+++ b/src/widget/windowing/WindowFrameWidget.cpp
@@ -34,9 +34,10 @@ int WindowFrameWidget::s_next_z_order = 1;
 int WindowFrameWidget::s_instance_count = 0;
 SDL_Cursor* WindowFrameWidget::s_cursor_nwse = nullptr;
 
-WindowFrameWidget::WindowFrameWidget(int client_width, int client_height, const std::string& title)
+WindowFrameWidget::WindowFrameWidget(int client_width, int client_height, const std::string& title, Font* font)
     : Widget()
     , m_title(title)
+    , m_font(font)
     , m_client_width(client_width)
     , m_client_height(client_height)
     , m_z_order(s_next_z_order++)
@@ -558,7 +559,19 @@ void WindowFrameWidget::rebuildSurface()
         frame_surface->hline(inner_x2, outer_x2, bottom_notch_y, 0, 0, 0, 255);
     }
     
-    // TODO: Add title text rendering when font access is available
+    // Render title text
+    if (m_font && !m_title.empty()) {
+        auto text_surface = m_font->Render(TagLib::String(m_title), 255, 255, 255);
+        if (text_surface) {
+            // Center horizontally in the titlebar area
+            int text_x = content_x + (content_width - text_surface->width()) / 2;
+
+            // Center vertically in the titlebar
+            int text_y = content_y + (TITLEBAR_HEIGHT - text_surface->height()) / 2;
+
+            frame_surface->Blit(*text_surface, Rect(text_x, text_y, text_surface->width(), text_surface->height()));
+        }
+    }
     
     // Draw window control buttons
     drawWindowControls(*frame_surface);

--- a/src/widget/windowing/WindowWidget.cpp
+++ b/src/widget/windowing/WindowWidget.cpp
@@ -31,14 +31,14 @@ using Foundation::Widget;
 
 int WindowWidget::s_next_z_order = 1;
 
-WindowWidget::WindowWidget(int client_width, int client_height, const std::string& title)
+WindowWidget::WindowWidget(int client_width, int client_height, const std::string& title, Font* font)
     : Widget()
     , m_client_width(client_width)
     , m_client_height(client_height)
     , m_z_order(s_next_z_order++)
 {
     // Create WindowFrameWidget that will handle all the system decorations
-    m_frame_widget_owned = std::make_unique<WindowFrameWidget>(client_width, client_height, title);
+    m_frame_widget_owned = std::make_unique<WindowFrameWidget>(client_width, client_height, title, font);
     m_frame_widget = m_frame_widget_owned.get();
     
     // Set up frame widget callbacks to forward events to our event handlers


### PR DESCRIPTION
Implemented title text rendering in WindowFrameWidget by:
1. Updating `WindowFrameWidget` to accept a `Font*` in its constructor and store it.
2. Updating `rebuildSurface` in `WindowFrameWidget.cpp` to render the window title centered in the titlebar using the provided font.
3. Updating `WindowWidget` to accept and pass the font to `WindowFrameWidget`.
4. Updating `Player.cpp` to pass the application font to window creation calls.

Verified syntax correctness using dummy headers for dependencies (SDL, TagLib, DBus, etc.).

---
*PR created automatically by Jules for task [14177783311765298688](https://jules.google.com/task/14177783311765298688) started by @segin*