### PR TITLE
🔒 Enhance security: Cleanse plaintext password from memory in Last.fm config loading

### DIFF
--- a/src/lastfm/LastFM.cpp
+++ b/src/lastfm/LastFM.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "psymp3.h"
+#include <openssl/crypto.h>
 
 #ifndef _WIN32
 #include <sys/types.h>
@@ -77,6 +78,13 @@ void LastFM::readConfig()
             // Legacy password entry - migrate to hash
             if (!value.empty()) {
                 m_password_hash = md5Hash(value);
+
+                // Securely erase plaintext password from memory (Requirements 7.5, Security Directive)
+                OPENSSL_cleanse(&value[0], value.length());
+                if (line.length() > equals + 1) {
+                    OPENSSL_cleanse(&line[equals + 1], line.length() - (equals + 1));
+                }
+
                 DEBUG_LOG_LAZY("lastfm", "Legacy password loaded and migrated to hash");
             }
         } else if (key == "password_hash") {


### PR DESCRIPTION
This change enhances the security of the Last.fm configuration loading process.

🎯 **What:**
- Added explicit memory cleansing (`OPENSSL_cleanse`) for the plaintext password variable (`value`) and the sensitive part of the line buffer immediately after it is hashed in `LastFM::readConfig`.
- Added explicit `#include <openssl/crypto.h>` to `src/lastfm/LastFM.cpp` to ensure `OPENSSL_cleanse` availability.

⚠️ **Risk:**
- Previously, while the password was not logged (the reported vulnerability was already fixed in the codebase), the plaintext password could linger in memory (stack/heap) after being read from the config file, potentially being exposed in core dumps or memory scraping.

🛡️ **Solution:**
- The plaintext password is now zeroed out from memory as soon as it is no longer needed (immediately after hashing), following security best practices and the project's memory directives.
- Verified that the reported logging vulnerability (logging password length) was already absent from the codebase.

---
*PR created automatically by Jules for task [9954912221644712838](https://jules.google.com/task/9954912221644712838) started by @segin*