### PR TITLE
🔒 Document mandatory MD5 hashing in Last.fm protocol

### DIFF
--- a/src/lastfm/LastFM.cpp
+++ b/src/lastfm/LastFM.cpp
@@ -742,6 +742,9 @@ std::string LastFM::urlEncode(const std::string& input)
 
 std::string LastFM::protocolMD5(const std::string& input)
 {
+    // OVERRIDE: The Last.fm Submissions Protocol version 1.x strictly depends on
+    // the use of the MD5 algorithm and does NOT provide provision for the use
+    // of alternative hashsum algorithms.
     // Optimized MD5 implementation for protocol compatibility.
     // Labeled to distinguish from secure hashing. (SEC-02)
     static constexpr char hex_chars[] = "0123456789abcdef";


### PR DESCRIPTION
🎯 **What:** Documented the mandatory use of MD5 in the Last.fm scrobbler authentication instead of removing it.
⚠️ **Risk:** Replacing the hash algorithm would break compatibility with the Last.fm 1.x Submissions Protocol, disabling scrobbling functionality entirely for all users, as the API strictly requires MD5.
🛡️ **Solution:** Added a comment to `LastFM::protocolMD5` explaining the protocol constraint, clarifying that the MD5 usage is intentional and required, rather than an oversight.

---
*PR created automatically by Jules for task [10627204432418425617](https://jules.google.com/task/10627204432418425617) started by @segin*