### PR TITLE
🧹 Remove placeholder commented out code in FLACCodec.cpp

### DIFF
--- a/src/codecs/flac/FLACCodec.cpp
+++ b/src/codecs/flac/FLACCodec.cpp
@@ -10457,13 +10457,6 @@ bool FLACCodec::validateReservedBitDepthValues_unlocked(uint16_t bits_per_sample
     // Currently no reserved bit depth values in RFC 9639
     // All values from 4 to 32 bits are valid per the specification
     
-    // Future reserved values could be added here as the specification evolves
-    // For example, if certain bit depths become deprecated or reserved:
-    // if (bits_per_sample == FUTURE_RESERVED_VALUE) {
-    //     Debug::log("flac_codec", "[validateReservedBitDepthValues_unlocked] Reserved bit depth: ", bits_per_sample);
-    //     return false;
-    // }
-    
     // Check for unusual bit depths that might indicate encoding issues
     // While not reserved, these are uncommon and may indicate problems
     static const uint16_t common_depths[] = {8, 16, 24, 32};


### PR DESCRIPTION
This change removes a block of commented-out placeholder code in `src/codecs/flac/FLACCodec.cpp` that was intended for future reserved bit depths. Removing such placeholder comments is a standard code health practice to improve maintainability and readability.

🎯 **What:** The code health issue addressed was the presence of dead, commented-out example code.
💡 **Why:** This improves maintainability by reducing noise in the codebase.
✅ **Verification:** The change was verified by reading the modified file to ensure only the target comments were removed. A full test suite run using `bash tests/verify_all_tests.sh` confirmed no regressions.
✨ **Result:** A cleaner and more readable implementation of `validateReservedBitDepthValues_unlocked`.

---
*PR created automatically by Jules for task [12714070289550177819](https://jules.google.com/task/12714070289550177819) started by @segin*