### PR TITLE
🧹 [code health] remove commented-out future reserved value check in FLACCodec

### DIFF
--- a/src/codecs/flac/FLACCodec.cpp
+++ b/src/codecs/flac/FLACCodec.cpp
@@ -10457,13 +10457,6 @@ bool FLACCodec::validateReservedBitDepthValues_unlocked(uint16_t bits_per_sample
     // Currently no reserved bit depth values in RFC 9639
     // All values from 4 to 32 bits are valid per the specification
     
-    // Future reserved values could be added here as the specification evolves
-    // For example, if certain bit depths become deprecated or reserved:
-    // if (bits_per_sample == FUTURE_RESERVED_VALUE) {
-    //     Debug::log("flac_codec", "[validateReservedBitDepthValues_unlocked] Reserved bit depth: ", bits_per_sample);
-    //     return false;
-    // }
-    
     // Check for unusual bit depths that might indicate encoding issues
     // While not reserved, these are uncommon and may indicate problems
     static const uint16_t common_depths[] = {8, 16, 24, 32};


### PR DESCRIPTION
This PR removes a commented-out code block in `src/codecs/flac/FLACCodec.cpp` that was intended for "future reserved value" checks. 

### 🎯 What:
Removed lines 10460-10465 in `src/codecs/flac/FLACCodec.cpp` which contained a commented-out check for `bits_per_sample == FUTURE_RESERVED_VALUE` and its explanatory comments.

### 💡 Why:
RFC 9639 defines all values from 4 to 32 bits as valid. The removed code was a placeholder for potential future specification updates. Keeping commented-out code for "future proofing" clutters the codebase and reduces readability.

### ✅ Verification:
- Manually inspected `src/codecs/flac/FLACCodec.cpp` to confirm the removal.
- Ran the full test suite using `bash tests/verify_all_tests.sh` to ensure no general regressions.
- All tests passed successfully.

### ✨ Result:
Improved codebase maintainability and readability by removing dead code.

---
*PR created automatically by Jules for task [797176894356758271](https://jules.google.com/task/797176894356758271) started by @segin*