### PR TITLE
Improve overflow check in repro_wav_overflow.cpp

### DIFF
--- a/tests/repro_wav_overflow.cpp
+++ b/tests/repro_wav_overflow.cpp
@@ -76,16 +76,21 @@ public:
             }
 
             // Seek to the next chunk, accounting for padding byte if chunk size is odd.
-            // FIX: Check for overflow
-            simulated_long next_chunk_pos = chunk_start_pos + chunk_size;
-            if (next_chunk_pos < chunk_start_pos) {
+            if (chunk_size > static_cast<uint32_t>(std::numeric_limits<simulated_long>::max())) {
                  std::cout << "Overflow check triggered!" << std::endl;
                  throw BadFormatException("WAVE chunk size causes overflow.");
             }
 
+            simulated_long s_chunk_size = static_cast<simulated_long>(chunk_size);
+            simulated_long padding = static_cast<simulated_long>(chunk_size % 2);
+
+            if (s_chunk_size > std::numeric_limits<simulated_long>::max() - chunk_start_pos - padding) {
+                 std::cout << "Overflow check triggered!" << std::endl;
+                 throw BadFormatException("WAVE chunk size causes overflow.");
+            }
+
+            simulated_long next_chunk_pos = chunk_start_pos + s_chunk_size + padding;
             m_handler->seek(next_chunk_pos, SEEK_SET);
-            if (chunk_size % 2 != 0)
-                m_handler->seek(1, SEEK_CUR);
 
             // Break loop for repro purposes (only need one iteration)
             break;


### PR DESCRIPTION
Improved the overflow check in `tests/repro_wav_overflow.cpp` by implementing a pre-overflow check that accounts for the alignment padding byte and performs a single seek operation. This replaces the less robust post-overflow check and ensures correct handling of large WAVE chunks in the reproduction test.

---
*PR created automatically by Jules for task [17961338087190320939](https://jules.google.com/task/17961338087190320939) started by @segin*