### PR TITLE
🔒 [security fix] Replace insecure rand() with C++11 random in HTTPIOHandler

### DIFF
--- a/src/io/http/HTTPIOHandler.cpp
+++ b/src/io/http/HTTPIOHandler.cpp
@@ -8,6 +8,9 @@
  */
 
 #include "psymp3.h"
+#include <random>
+#include <algorithm>
+
 namespace PsyMP3 {
 namespace IO {
 namespace HTTP {
@@ -1120,10 +1123,15 @@ HTTPClient::Response HTTPIOHandler::retryNetworkOperation(std::function<HTTPClie
         Debug::log("http", "HTTPIOHandler::retryNetworkOperation() - ", operation_name, " failed (HTTP ", response.statusCode, ": ", response.statusMessage, "), retrying (", retry_count, "/", max_retries, ")");
         
         // Calculate delay with exponential backoff and jitter
-        int delay = base_delay_ms * (1 << (retry_count - 1)); // Exponential backoff
+        // Limit retry_count to prevent integer overflow
+        int backoff_exponent = std::min(retry_count - 1, 14); // 2^14 * 1000 is ~16 seconds
+        int delay = base_delay_ms * (1 << backoff_exponent); // Exponential backoff
         
         // Add jitter to prevent thundering herd
-        int jitter = rand() % (delay / 4 + 1); // Up to 25% jitter
+        static thread_local std::random_device rd;
+        static thread_local std::mt19937 gen(rd());
+        std::uniform_int_distribution<int> dis(0, delay / 4);
+        int jitter = dis(gen); // Up to 25% jitter
         delay += jitter;
         
         // Cap maximum delay at 30 seconds


### PR DESCRIPTION
🎯 **What:** Replaced the insecure and predictable `rand()` function with the modern C++ `<random>` library for generating network backoff jitter in `HTTPIOHandler::retryNetworkOperation`.

⚠️ **Risk:** `rand()` is cryptographically weak and predictable, which could potentially be exploited to synchronize or predict retry attempts in some network-based attack scenarios. Additionally, the exponential backoff calculation was vulnerable to integer overflow for large retry counts.

🛡️ **Solution:**
- Used `std::mt19937` (Mersenne Twister) seeded by `std::random_device` for high-quality, thread-safe random number generation using `thread_local` storage.
- Used `std::uniform_int_distribution` to correctly map random bits to the desired jitter range.
- Added explicit `#include <random>` and `#include <algorithm>` headers.
- Capped the retry exponent to 14 to prevent integer overflow in the backoff calculation.

---
*PR created automatically by Jules for task [627752105022755251](https://jules.google.com/task/627752105022755251) started by @segin*