### PR TITLE
🧹 Remove unused static variable in fft.cpp

### DIFF
--- a/src/core/fft.cpp
+++ b/src/core/fft.cpp
@@ -30,9 +30,6 @@ namespace PsyMP3 {
 namespace Core {
 
 
-// Define I for float complex
-static const std::complex<float> I_f(0.0f, 1.0f);
-
 /**
  * @brief Constructs an FFT object for a given size.
  * @param size The number of samples for the FFT, which must be a power of two.


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an unused static constant variable `I_f` in `src/core/fft.cpp`.
💡 **Why:** How this improves maintainability is by removing dead code, cleaning up the file, and preventing `-Wunused-variable` warnings (which are treated as errors in this project).
✅ **Verification:** I ran the test suite (`bash tests/verify_all_tests.sh`) and confirmed all tests pass with no regressions.
✨ **Result:** The codebase is cleaner and adheres to the project's strict warning policies.

---
*PR created automatically by Jules for task [12899465435499742956](https://jules.google.com/task/12899465435499742956) started by @segin*