### PR TITLE
🧹 Remove dead sleep code in MPRISTypes.cpp

### DIFF
--- a/src/mpris/MPRISTypes.cpp
+++ b/src/mpris/MPRISTypes.cpp
@@ -698,9 +698,6 @@ bool ErrorRecoveryManager::attemptRecovery(
   int attempt = m_attempt_counts[category];
   auto delay = calculateDelay(category, attempt);
 
-  // In a real implementation, you might want to sleep here
-  // std::this_thread::sleep_for(delay);
-
   m_attempt_counts[category]++;
   m_last_attempt_times[category] = std::chrono::system_clock::now();
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out `std::this_thread::sleep_for(delay)` and its corresponding comment in `src/mpris/MPRISTypes.cpp`.

💡 **Why:** This improves maintainability and readability by eliminating unnecessary dead code.

✅ **Verification:** Verified the code health issue is resolved by removing the two lines. The `tests/verify_all_tests.sh` test suite was run and passed, ensuring that no regressions were introduced.

✨ **Result:** A cleaner implementation of `attemptRecovery` that is easier to read and maintain.

---
*PR created automatically by Jules for task [11417003927837909035](https://jules.google.com/task/11417003927837909035) started by @segin*