### PR TITLE
🧹 Code Health: Remove unused bits-per-sample extraction logic in FLACHeaderParser

### DIFF
--- a/src/demuxer/ogg/FLACHeaderParser.cpp
+++ b/src/demuxer/ogg/FLACHeaderParser.cpp
@@ -87,9 +87,6 @@ bool FLACHeaderParser::parseHeader(ogg_packet* packet) {
         int channels_minus_1 = (streaminfo[12] >> 1) & 0x07;
         m_info.channels = channels_minus_1 + 1;
         
-        // Bits Per Sample: 5 bits (bit 0 of 12, top 4 of 13)
-        // int bps_minus_1 = ((streaminfo[12] & 0x01) << 4) | ((streaminfo[13] >> 4) & 0x0F);
-        
         m_streaminfo_found = true;
         m_headers_count = 1;
         


### PR DESCRIPTION
🎯 **What:** Removed commented-out logic regarding `bps_minus_1` extraction in `src/demuxer/ogg/FLACHeaderParser.cpp`.
💡 **Why:** To improve codebase maintainability and readability by deleting dead/unused code that has no effect on execution.
✅ **Verification:** Re-ran tests using `bash tests/verify_all_tests.sh` to ensure everything compiles and passes properly without regressions. Checked that the removed code was exclusively comments.
✨ **Result:** A cleaner FLAC header parser file.

---
*PR created automatically by Jules for task [11345141665877447023](https://jules.google.com/task/11345141665877447023) started by @segin*