### PR TITLE
🧹 [code health] Remove commented-out code block in HTTPClient.cpp

### DIFF
--- a/src/io/http/HTTPClient.cpp
+++ b/src/io/http/HTTPClient.cpp
@@ -26,10 +26,6 @@ class Debug {
 public:
     template<typename... Args>
     static void log(const std::string& channel, Args&&... args) {
-        // Optional: print to stderr for debugging tests
-        // std::cerr << "[DEBUG] " << channel << ": ";
-        // ((std::cerr << args), ...);
-        // std::cerr << std::endl;
     }
 };
 


### PR DESCRIPTION
🎯 **What:** Removed a block of commented-out debug logging code in `src/io/http/HTTPClient.cpp`.
💡 **Why:** To improve code health, readability, and maintainability by removing dead code.
✅ **Verification:** Ran the full test suite using `bash tests/verify_all_tests.sh` to ensure the codebase still compiles and no functionality is broken. Received a positive code review confirming the changes are safe and correctly implemented.
✨ **Result:** Improved codebase cleanliness without altering any functionality.

---
*PR created automatically by Jules for task [17963080209501787575](https://jules.google.com/task/17963080209501787575) started by @segin*