### PR TITLE
Remove boilerplate TODOs in stdafx headers

### DIFF
--- a/libs/libseven/libseven/stdafx.cpp
+++ b/libs/libseven/libseven/stdafx.cpp
@@ -3,6 +3,3 @@
 // stdafx.obj will contain the pre-compiled type information
 
 #include "stdafx.h"
-
-// TODO: reference any additional headers you need in STDAFX.H
-// and not in this file

--- a/libs/libseven/libseven/stdafx.h
+++ b/libs/libseven/libseven/stdafx.h
@@ -11,5 +11,3 @@
 // Windows Header Files:
 #include <windows.h>
 #include <shobjidl.h>
-
-// TODO: reference additional headers your program requires here


### PR DESCRIPTION
The user requested addressing the TODO about referencing additional headers in `STDAFX.H`. The TODO in `stdafx.cpp` and `stdafx.h` are just boilerplate and not actionable since there's no additional headers required to include. The best solution is simply removing them. I modified the `.cpp` and `.h` to remove the TODOs and maintained their DOS line endings.

---
*PR created automatically by Jules for task [13082209535598842301](https://jules.google.com/task/13082209535598842301) started by @segin*