### PR TITLE
🔒 Fix insecure random number generation in HTTPIOHandler

### DIFF
--- a/src/io/http/HTTPIOHandler.cpp
+++ b/src/io/http/HTTPIOHandler.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "psymp3.h"
+#include <random>
 namespace PsyMP3 {
 namespace IO {
 namespace HTTP {
@@ -1123,7 +1124,9 @@ HTTPClient::Response HTTPIOHandler::retryNetworkOperation(std::function<HTTPClie
         int delay = base_delay_ms * (1 << (retry_count - 1)); // Exponential backoff
         
         // Add jitter to prevent thundering herd
-        int jitter = rand() % (delay / 4 + 1); // Up to 25% jitter
+        static thread_local std::mt19937 generator(std::random_device{}());
+        std::uniform_int_distribution<int> distribution(0, delay / 4);
+        int jitter = distribution(generator); // Up to 25% jitter
         delay += jitter;
         
         // Cap maximum delay at 30 seconds


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of the insecure `rand()` function for calculating retry delay jitter in `src/io/http/HTTPIOHandler.cpp`.
⚠️ **Risk:** While the usage of `rand()` here is limited to network jitter rather than cryptographic operations, `rand()` is generally discouraged in C++ due to predictability and potential lack of thread-safety in some implementations. An attacker could potentially predict network retry patterns, leading to thundering herd problems or easier denial-of-service conditions if backoff logic is manipulated.
🛡️ **Solution:** The `rand()` function was replaced with C++11's `<random>` library. A `static thread_local std::mt19937` generator seeded by `std::random_device{}` is now used alongside `std::uniform_int_distribution<int>` to securely generate jitter. The `<random>` header was also explicitly included.

---
*PR created automatically by Jules for task [14056160406089264331](https://jules.google.com/task/14056160406089264331) started by @segin*