### PR TITLE
Include required standard headers in libseven stdafx.h

### DIFF
--- a/libs/libseven/libseven/stdafx.h
+++ b/libs/libseven/libseven/stdafx.h
@@ -12,4 +12,6 @@
 #include <windows.h>
 #include <shobjidl.h>
 
-// TODO: reference additional headers your program requires here
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>


### PR DESCRIPTION
The standard C library headers `<stdlib.h>`, `<string.h>`, and `<wchar.h>` were added to `libs/libseven/libseven/stdafx.h` to address the boilerplate `TODO: reference additional headers your program requires here` comment. These headers are required by `libseven.cpp` which utilizes `malloc`, `calloc`, `free`, `strlen`, and `wcsncpy`.

---
*PR created automatically by Jules for task [5664709403742152766](https://jules.google.com/task/5664709403742152766) started by @segin*