### PR TITLE
🔒 fix(lastfm): address CWE-312 and document API-mandated MD5 usage

### DIFF
--- a/include/lastfm/LastFM.h
+++ b/include/lastfm/LastFM.h
@@ -87,7 +87,7 @@ private:
     std::queue<NowPlayingRequest> m_nowplaying_requests;
     std::string m_session_key;
     std::string m_username;
-    std::string m_password_hash;  // Cached MD5 hash of password (Mandated by protocol)
+    std::string m_password_hash;  // Cached MD5 hash of password (Mandated by protocol). Memory is explicitly cleansed on destruction.
     std::string m_config_file;
     std::string m_cache_file;
     

--- a/src/lastfm/LastFM.cpp
+++ b/src/lastfm/LastFM.cpp
@@ -50,6 +50,14 @@ LastFM::~LastFM()
     saveScrobbles();
     writeConfig();
     
+    // Securely clear credentials from memory (CWE-312)
+    if (!m_password_hash.empty()) {
+        OPENSSL_cleanse(&m_password_hash[0], m_password_hash.length());
+    }
+    if (!m_session_key.empty()) {
+        OPENSSL_cleanse(&m_session_key[0], m_session_key.length());
+    }
+
     DEBUG_LOG_LAZY("lastfm", "LastFM shutdown complete, pending scrobbles saved");
 }
 
@@ -175,7 +183,19 @@ bool LastFM::performHandshake(int host_index)
     // Use cached password hash to avoid redundant computation (Requirements 1.3)
     time_t timestamp = time(nullptr);
     
-    std::string auth_token = protocolMD5(m_password_hash + std::to_string(timestamp));
+    // Avoid creating temporary strings containing sensitive data (CWE-312)
+    std::string timestamp_str = std::to_string(timestamp);
+    std::string auth_data;
+    auth_data.reserve(m_password_hash.length() + timestamp_str.length());
+    auth_data += m_password_hash;
+    auth_data += timestamp_str;
+
+    // lgtm[cpp/weak-cryptographic-algorithm]
+    // NOLINTNEXTLINE(cert-msc50-cpp, cert-msc68-cpp)
+    std::string auth_token = protocolMD5(auth_data);
+
+    // Securely clear the auth data from memory
+    OPENSSL_cleanse(&auth_data[0], auth_data.length());
     
     // Build handshake URL using efficient string concatenation (Requirements 2.3)
     // Use HTTPS for security (SEC-04)
@@ -747,11 +767,13 @@ std::string LastFM::protocolMD5(const std::string& input)
     // of alternative hashsum algorithms.
     // Optimized MD5 implementation for protocol compatibility.
     // Labeled to distinguish from secure hashing. (SEC-02)
+    // lgtm[cpp/weak-cryptographic-algorithm]
     static constexpr char hex_chars[] = "0123456789abcdef";
     
     unsigned char hash[EVP_MAX_MD_SIZE];
     unsigned int hash_len = 0;
     
+    // NOLINTNEXTLINE(cert-msc50-cpp, cert-msc68-cpp)
     if (EVP_Digest(input.c_str(), input.length(), hash, &hash_len, EVP_md5(), nullptr)) {
         
         // Pre-allocate output string (MD5 is 16 bytes = 32 hex chars)


### PR DESCRIPTION
This PR addresses a static analysis security finding regarding the use of the weak cryptographic algorithm (MD5) for authentication within `src/lastfm/LastFM.cpp`.

🎯 **What:** The vulnerability fixed
The system was using MD5 for `auth_token` generation which is a known weak cryptographic algorithm. Furthermore, `m_password_hash` and temporary authentication strings were left unscrubbed in memory upon completion or object destruction (CWE-312).

⚠️ **Risk:** The potential impact if left unfixed
While the MD5 algorithm is structurally mandated by the Last.fm 1.2 API, leaving the generated strings and the stored hashes unscrubbed in memory meant that if the application crashed or its memory was dumped or swapped, user credentials (`m_password_hash` and `m_session_key`) could be exposed.

🛡️ **Solution:** How the fix addresses the vulnerability
Because replacing MD5 with a secure algorithm (like SHA-256) breaks the API contract, the MD5 usage has been explicitly documented and suppressed for static analysis tools using standard tags (`// lgtm[cpp/weak-cryptographic-algorithm]` and `// NOLINTNEXTLINE`).

The true security risk of lingering credentials in memory has been mitigated by explicitly calling `OPENSSL_cleanse()` (using `.length()` to avoid string capacity corruption) on:
1. The temporary `auth_data` buffer immediately after the hash is computed.
2. `m_password_hash` and `m_session_key` within the `~LastFM()` destructor.

---
*PR created automatically by Jules for task [1890426715006165368](https://jules.google.com/task/1890426715006165368) started by @segin*