### PR TITLE
🧪 [Test] Improve test coverage for RAIIFileHandle error paths

### DIFF
--- a/tests/test_raii_file_handle.cpp
+++ b/tests/test_raii_file_handle.cpp
@@ -7,6 +7,23 @@
 #include <iostream>
 #include <string>
 #include <fstream>
+#include <cstdio>
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+
+// Mock Debug so we can include the real RAIIFileHandle implementation
+// Since we are testing a single file without the full build system
+namespace PsyMP3 {
+namespace Debug {
+    template<typename... Args>
+    void log(const char* channel, Args&&... args) {
+        // Suppress debug output during tests to keep console clean
+    }
+}
+}
 
 // Simple test framework
 namespace SimpleTest {
@@ -25,94 +42,23 @@ namespace SimpleTest {
     }
 }
 
-// Mock RAIIFileHandle for testing (simplified version)
-class MockRAIIFileHandle {
-private:
-    FILE* m_file;
-    bool m_owns_handle;
-    
-public:
-    MockRAIIFileHandle() : m_file(nullptr), m_owns_handle(false) {
-        SimpleTest::log("RAIIFileHandle default constructor");
-    }
-    
-    explicit MockRAIIFileHandle(FILE* file, bool take_ownership = true) 
-        : m_file(file), m_owns_handle(take_ownership) {
-        SimpleTest::log("RAIIFileHandle constructor with file handle");
-    }
-    
-    MockRAIIFileHandle(MockRAIIFileHandle&& other) noexcept 
-        : m_file(other.m_file), m_owns_handle(other.m_owns_handle) {
-        other.m_file = nullptr;
-        other.m_owns_handle = false;
-        SimpleTest::log("RAIIFileHandle move constructor");
-    }
-    
-    MockRAIIFileHandle& operator=(MockRAIIFileHandle&& other) noexcept {
-        if (this != &other) {
-            close();
-            m_file = other.m_file;
-            m_owns_handle = other.m_owns_handle;
-            other.m_file = nullptr;
-            other.m_owns_handle = false;
-            SimpleTest::log("RAIIFileHandle move assignment");
-        }
-        return *this;
-    }
-    
-    ~MockRAIIFileHandle() {
-        SimpleTest::log("RAIIFileHandle destructor");
-        close();
-    }
-    
-    // Delete copy operations
-    MockRAIIFileHandle(const MockRAIIFileHandle&) = delete;
-    MockRAIIFileHandle& operator=(const MockRAIIFileHandle&) = delete;
-    
-    bool open(const char* filename, const char* mode) {
-        close();
-        if (filename && mode) {
-            m_file = fopen(filename, mode);
-            m_owns_handle = (m_file != nullptr);
-            SimpleTest::log(std::string("File open: ") + filename + " - " + (m_file ? "success" : "failed"));
-            return m_file != nullptr;
-        }
-        return false;
-    }
-    
-    int close() {
-        int result = 0;
-        if (m_file && m_owns_handle) {
-            result = fclose(m_file);
-            SimpleTest::log("File closed");
-        }
-        m_file = nullptr;
-        m_owns_handle = false;
-        return result;
-    }
-    
-    FILE* get() const { return m_file; }
-    bool is_valid() const { return m_file != nullptr; }
-    bool owns_handle() const { return m_owns_handle; }
-    
-    FILE* release() {
-        FILE* file = m_file;
-        m_file = nullptr;
-        m_owns_handle = false;
-        SimpleTest::log("File handle released");
-        return file;
-    }
-    
-    void reset(FILE* file = nullptr, bool take_ownership = true) {
-        close();
-        m_file = file;
-        m_owns_handle = take_ownership;
-        SimpleTest::log("File handle reset");
-    }
-    
-    explicit operator bool() const { return is_valid(); }
-    operator FILE*() const { return m_file; }
-};
+// Include what we need and define PSYMP3_H to prevent the main header from loading
+// and causing SDL.h and other missing dependencies errors.
+// Because src/io/RAIIFileHandle.cpp includes "psymp3.h" specifically,
+// we must mock it by creating a dummy local header or defining the guard it expects.
+#ifndef __PSYMP3_H__
+#define __PSYMP3_H__
+#endif
+namespace PsyMP3 {
+    class SDLException : public std::runtime_error {
+    public:
+        explicit SDLException(const std::string& msg) : std::runtime_error(msg) {}
+    };
+}
+#include "../include/RAIIFileHandle.h"
+#include "../src/io/RAIIFileHandle.cpp"
+
+using namespace PsyMP3::IO;
 
 // Test functions
 bool test_raii_basic_functionality() {
@@ -127,7 +73,7 @@ bool test_raii_basic_functionality() {
     
     // Test 1: Basic file opening and automatic closing
     {
-        MockRAIIFileHandle handle;
+        RAIIFileHandle handle;
         if (!SimpleTest::assert_true(handle.open(test_filename, "r"), "File opened successfully")) {
             return false;
         }
@@ -161,10 +107,10 @@ bool test_raii_move_semantics() {
     
     // Test move constructor
     {
-        MockRAIIFileHandle handle1;
+        RAIIFileHandle handle1;
         handle1.open(test_filename, "r");
         
-        MockRAIIFileHandle handle2 = std::move(handle1);
+        RAIIFileHandle handle2 = std::move(handle1);
         
         if (!SimpleTest::assert_true(!handle1.is_valid(), "Original handle is invalid after move")) {
             return false;
@@ -177,8 +123,8 @@ bool test_raii_move_semantics() {
     
     // Test move assignment
     {
-        MockRAIIFileHandle handle1;
-        MockRAIIFileHandle handle2;
+        RAIIFileHandle handle1;
+        RAIIFileHandle handle2;
         
         handle1.open(test_filename, "r");
         handle2 = std::move(handle1);
@@ -210,7 +156,7 @@ bool test_raii_resource_management() {
     
     // Test release functionality
     {
-        MockRAIIFileHandle handle;
+        RAIIFileHandle handle;
         handle.open(test_filename, "r");
         
         FILE* raw_file = handle.release();
@@ -233,7 +179,7 @@ bool test_raii_resource_management() {
     
     // Test reset functionality
     {
-        MockRAIIFileHandle handle;
+        RAIIFileHandle handle;
         FILE* raw_file = fopen(test_filename, "r");
         
         handle.reset(raw_file, true);
@@ -267,7 +213,7 @@ bool test_raii_exception_safety() {
     
     // Test that files are properly closed even when exceptions occur
     try {
-        MockRAIIFileHandle handle;
+        RAIIFileHandle handle;
         handle.open(test_filename, "r");
         
         if (!SimpleTest::assert_true(handle.is_valid(), "File opened before exception")) {
@@ -306,7 +252,7 @@ bool test_raii_multiple_instances() {
     
     // Test multiple RAII handles
     {
-        MockRAIIFileHandle handles[3];
+        RAIIFileHandle handles[3];
         
         for (int i = 0; i < 3; i++) {
             if (!handles[i].open(test_files[i], "r")) {
@@ -334,6 +280,34 @@ bool test_raii_multiple_instances() {
     return true;
 }
 
+bool test_raii_make_file_handle() {
+    SimpleTest::log("=== Testing make_file_handle ===");
+
+    // Test 1: Successful file creation
+    const char* test_filename = "test_make_handle.txt";
+    {
+        std::ofstream test_file(test_filename);
+        test_file << "Hello, make_file_handle!";
+    }
+
+    RAIIFileHandle handle = make_file_handle(test_filename, "r");
+    if (!SimpleTest::assert_true(handle.is_valid(), "File handle is valid for existing file")) {
+        return false;
+    }
+
+    std::remove(test_filename);
+
+    // Test 2: Error path - Non-existent file
+    const char* non_existent = "non_existent_file_12345.txt";
+    RAIIFileHandle invalid_handle = make_file_handle(non_existent, "r");
+
+    if (!SimpleTest::assert_true(!invalid_handle.is_valid(), "File handle is invalid for non-existent file")) {
+        return false;
+    }
+
+    return true;
+}
+
 int main() {
     SimpleTest::log("=== RAII File Handle Tests ===");
     
@@ -344,6 +318,7 @@ int main() {
     all_passed &= test_raii_resource_management();
     all_passed &= test_raii_exception_safety();
     all_passed &= test_raii_multiple_instances();
+    all_passed &= test_raii_make_file_handle();
     
     if (all_passed) {
         SimpleTest::log("=== All RAII File Handle Tests PASSED ===");


### PR DESCRIPTION
🎯 **What:** The testing gap for `make_file_handle` in `src/io/RAIIFileHandle.cpp` was addressed by adding a test case that relies on standard C/C++ file I/O behavior without using mock objects.

📊 **Coverage:** The real `RAIIFileHandle` implementation is now tested in `test_raii_file_handle.cpp`, specifically covering the error path where `make_file_handle` attempts to open a non-existent file. Existing functionality tests were also migrated to use the real object instead of the mock.

✨ **Result:** Improved test coverage and reliability for RAII file handle operations by verifying they properly return an invalid handle upon file open failure.

---
*PR created automatically by Jules for task [16481299814505644884](https://jules.google.com/task/16481299814505644884) started by @segin*