### PR TITLE
🧪 [Testing Improvement] Add specific malformed UTF-8 tests for decodeUTF8Safe

### DIFF
--- a/tests/test_tag_properties.cpp
+++ b/tests/test_tag_properties.cpp
@@ -972,6 +972,30 @@ bool runRapidCheckTests() {
     });
     if (!result51) { all_passed = false; std::cout << "FAILED\n"; } else { std::cout << "PASSED\n"; }
     
+    // Property: decodeUTF8Safe handles specific malformed sequences correctly
+    std::cout << "  ID3v2_DecodeUTF8Safe_Malformed: ";
+    auto result51b = rc::check("decodeUTF8Safe handles specific malformed sequences correctly", []() {
+        // Test null and empty
+        RC_ASSERT(ID3v2Utils::decodeUTF8Safe(nullptr, 10) == "");
+        RC_ASSERT(ID3v2Utils::decodeUTF8Safe(reinterpret_cast<const uint8_t*>("data"), 0) == "");
+
+        std::vector<std::vector<uint8_t>> malformed_sequences = {
+            {0xFF}, // Invalid start byte
+            {0xC0, 0x80}, // Overlong encoding
+            {0xC2}, // Missing continuation byte
+            {0xE0, 0xA0}, // Missing continuation byte
+            {0xF0, 0x90, 0x80}, // Missing continuation byte
+            {0xED, 0xA0, 0x80}, // Surrogate pair
+            {0xF4, 0x90, 0x80, 0x80}, // Out of bounds (> U+10FFFF)
+        };
+
+        for (const auto& seq : malformed_sequences) {
+            std::string result = ID3v2Utils::decodeUTF8Safe(seq.data(), seq.size());
+            RC_ASSERT(ID3v2Utils::isValidUTF8(result));
+        }
+    });
+    if (!result51b) { all_passed = false; std::cout << "FAILED\n"; } else { std::cout << "PASSED\n"; }
+
     // Property: TagFactory never crashes on corrupted data
     std::cout << "  TagFactory_NeverCrashesOnCorruptedData: ";
     auto result52 = rc::check("TagFactory never crashes on corrupted data", []() {
@@ -2032,6 +2056,38 @@ protected:
     }
 };
 
+class ID3v2_DecodeUTF8Safe_Malformed : public TestCase {
+public:
+    ID3v2_DecodeUTF8Safe_Malformed()
+        : TestCase("ID3v2_DecodeUTF8Safe_Malformed") {}
+protected:
+    void runTest() override {
+        // Test null pointer
+        std::string result = ID3v2Utils::decodeUTF8Safe(nullptr, 10);
+        ASSERT_EQUALS(std::string(""), result, "decodeUTF8Safe with nullptr should return empty string");
+
+        // Test zero size
+        result = ID3v2Utils::decodeUTF8Safe(reinterpret_cast<const uint8_t*>("data"), 0);
+        ASSERT_EQUALS(std::string(""), result, "decodeUTF8Safe with size 0 should return empty string");
+
+        // Specific malformed sequences
+        std::vector<std::vector<uint8_t>> malformed_sequences = {
+            {0xFF}, // Invalid start byte
+            {0xC0, 0x80}, // Overlong encoding
+            {0xC2}, // Missing continuation byte
+            {0xE0, 0xA0}, // Missing continuation byte
+            {0xF0, 0x90, 0x80}, // Missing continuation byte
+            {0xED, 0xA0, 0x80}, // Surrogate pair
+            {0xF4, 0x90, 0x80, 0x80}, // Out of bounds (> U+10FFFF)
+        };
+
+        for (const auto& seq : malformed_sequences) {
+            std::string res = ID3v2Utils::decodeUTF8Safe(seq.data(), seq.size());
+            ASSERT_TRUE(ID3v2Utils::isValidUTF8(res), "Repaired sequence should be valid UTF-8");
+        }
+    }
+};
+
 class CorruptedData_TagFactory_NeverCrashesOnCorruptedData : public TestCase {
 public:
     CorruptedData_TagFactory_NeverCrashesOnCorruptedData() 
@@ -2116,6 +2172,7 @@ int main(int argc, char* argv[]) {
     suite.addTest(std::make_unique<CorruptedData_ID3v2_HandlesInvalidFrameSizes>());
     suite.addTest(std::make_unique<CorruptedData_ID3v2_APIC_HandlesCorruptedPictureData>());
     suite.addTest(std::make_unique<CorruptedData_InvalidUTF8_HandledGracefully>());
+    suite.addTest(std::make_unique<ID3v2_DecodeUTF8Safe_Malformed>());
     suite.addTest(std::make_unique<CorruptedData_TagFactory_NeverCrashesOnCorruptedData>());
     
     auto results = suite.runAll();


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This adds specific tests for `ID3v2Utils::decodeUTF8Safe` to check its capability to correctly repair malformed UTF-8 byte arrays.

📊 **Coverage:** What scenarios are now tested
The tests now specifically cover passing `nullptr`, a `size` of 0, as well as distinct malformed sequences:
- Invalid start byte (`0xFF`)
- Overlong encoding (`0xC0, 0x80`)
- Missing continuation bytes (`0xC2`, `0xE0, 0xA0`, `0xF0, 0x90, 0x80`)
- Surrogate pair (`0xED, 0xA0, 0x80`)
- Out of bounds sequence (`0xF4, 0x90, 0x80, 0x80`)

✨ **Result:** The improvement in test coverage
`decodeUTF8Safe` and the underlying `repairUTF8` function it delegates to are now explicitly verified for robust error recovery in handling ID3v2 string tags.

---
*PR created automatically by Jules for task [7918235949937465392](https://jules.google.com/task/7918235949937465392) started by @segin*