### PR TITLE
⚡ [Performance] Pass playlist args to populator loop by const reference

### DIFF
--- a/include/player.h
+++ b/include/player.h
@@ -112,7 +112,7 @@ class Player
         void requestTrackPreload(const TagLib::String& path);
         void requestChainedStreamLoad(const std::vector<TagLib::String>& paths);
         void loaderThreadLoop();
-        void playlistPopulatorLoop(std::vector<std::string> args);
+        void playlistPopulatorLoop(const std::vector<std::string>& args);
 
         void nextTrack(size_t advance_count = 1);
         void prevTrack(void);

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -292,7 +292,7 @@ void Player::loaderThreadLoop() {
  * appear immediately on startup, without waiting for file system access.
  * @param args The vector of command-line arguments passed to the application.
  */
-void Player::playlistPopulatorLoop(std::vector<std::string> args) {
+void Player::playlistPopulatorLoop(const std::vector<std::string>& args) {
     System::setThisThreadName("playlist-populator");
 
     if (args.empty()) return; // Nothing to do


### PR DESCRIPTION
💡 **What:** Changed `Player::playlistPopulatorLoop` to take `args` by `const std::vector<std::string>&` instead of by value.
🎯 **Why:** To eliminate an unnecessary copy of the `std::vector<std::string>` when the `playlistPopulatorLoop` function is invoked. When standard threads are created, the arguments are decayed and copied into the thread's internal storage, which are then passed to the thread function. Passing by value forces a secondary, redundant copy into the function scope. Taking it by const reference optimally avoids this overhead while preserving correctness.
📊 **Measured Improvement:** No performance baseline was captured as this change is a trivial, universally-accepted C++ optimization (avoiding a heap-allocated vector copy) with no risk to correctness. A performance benchmark for an initialization thread argument would be overly complex relative to the straightforward nature of the improvement. The correctness of the build was verified successfully.

---
*PR created automatically by Jules for task [4026588558596572670](https://jules.google.com/task/4026588558596572670) started by @segin*