### PR TITLE
🧹 Remove unused <iostream> from HTTPClient.cpp

### DIFF
--- a/src/io/http/HTTPClient.cpp
+++ b/src/io/http/HTTPClient.cpp
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <iostream>
 #include <sstream>
 #include <thread>
 #include <mutex>
@@ -42,7 +41,6 @@ public:
 #include <atomic>
 #include <thread>
 #include <chrono>
-#include <iostream>
 #include <sstream>
 #include <algorithm>
 #include <cstring>


### PR DESCRIPTION
🎯 **What:** Removed unused `<iostream>` header inclusions in `src/io/http/HTTPClient.cpp`.
💡 **Why:** Including unused headers increases compilation time and pollutes the global namespace.
✅ **Verification:** Confirmed successful compilation of `HTTPClient.cpp` in standalone mode and verified functionality with a custom test program.
✨ **Result:** Cleaner source code and slightly improved compilation performance for the HTTP module.

---
*PR created automatically by Jules for task [16708142527116510738](https://jules.google.com/task/16708142527116510738) started by @segin*