### PR TITLE
🧪 [testing improvement] Add unit tests for track utility functions

### DIFF
--- a/include/track.h
+++ b/include/track.h
@@ -37,6 +37,8 @@ class track
         TagLib::String GetTitle() const { return m_Title; }
         TagLib::String GetAlbum() const { return m_Album; }
         TagLib::String GetFilePath() const { return m_FilePath; }
+        static bool isKnownRawAudioExtension(const TagLib::String& path);
+        static bool shouldCreateTagLibRefForPath(const TagLib::String& path);
         explicit track(const TagLib::String& a_FilePath, const TagLib::String& extinf_artist = "", const TagLib::String& extinf_title = "", long extinf_duration = 0);
         void SetFilePath(TagLib::String val) { m_FilePath = val; }
         unsigned int GetLen() const { return m_Len; }

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -25,8 +25,7 @@
 
 TagLib::String track::nullstr;
 
-namespace {
-bool isKnownRawAudioExtension(const TagLib::String& path)
+bool track::isKnownRawAudioExtension(const TagLib::String& path)
 {
     std::string utf8_path = path.to8Bit(true);
     std::string::size_type dot = utf8_path.find_last_of('.');
@@ -47,14 +46,13 @@ bool isKnownRawAudioExtension(const TagLib::String& path)
     return kRawExtensions.find(extension) != kRawExtensions.end();
 }
 
-bool shouldCreateTagLibRefForPath(const TagLib::String& path)
+bool track::shouldCreateTagLibRefForPath(const TagLib::String& path)
 {
     if (path.isEmpty()) {
         return false;
     }
 
     return !isKnownRawAudioExtension(path);
-}
 }
 
 /**

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -388,7 +388,8 @@ check_PROGRAMS = test_rect_area_validation test_rect_containment test_rect_inter
 	test_enhanced_buffer_pool \
 	test_surface_from_bmp_error \
 	test_extensibility_utils \
-	test_lastfm_url_encode_unit
+	test_lastfm_url_encode_unit \
+	test_track_utils
 
 if HAVE_AAC
 check_PROGRAMS += test_aac_integration
@@ -1297,6 +1298,17 @@ endif
 # A-law codec table verification test
 test_alaw_table_verification_SOURCES = test_alaw_table_verification.cpp
 test_alaw_table_verification_LDADD = $(FULL_CODEC_LIBS) $(AM_LDFLAGS) $(COMMON_CODEC_LIBS)
+
+test_track_utils_SOURCES = test_track_utils.cpp
+test_track_utils_LDADD = \
+	libtest_utilities.a \
+	$(top_builddir)/src/track.o \
+	$(top_builddir)/src/io/file/libpsymp3-io-file.a \
+	$(top_builddir)/src/io/libpsymp3-io.a \
+	$(top_builddir)/src/debug.o \
+	$(top_builddir)/src/core/libpsymp3-core.a \
+	$(top_builddir)/src/core/utility/libpsymp3-core-utility.a \
+	$(AM_LDFLAGS)
 
 test_raw_audio_tag_safety_SOURCES = test_raw_audio_tag_safety.cpp
 test_raw_audio_tag_safety_LDADD = \

--- a/tests/test_track_utils.cpp
+++ b/tests/test_track_utils.cpp
@@ -1,0 +1,68 @@
+/*
+ * tests/test_track_utils.cpp - Unit tests for track utility functions
+ * This file is part of PsyMP3.
+ * Copyright © 2026 Kirn Gill <segin2005@gmail.com>
+ *
+ * PsyMP3 is free software. You may redistribute and/or modify it under
+ * the terms of the ISC License <https://opensource.org/licenses/ISC>
+ */
+
+#include "psymp3.h"
+#include "test_framework.h"
+
+using namespace TestFramework;
+
+class TrackUtilsTest : public TestCase {
+public:
+    TrackUtilsTest() : TestCase("Track utility functions tests") {}
+
+protected:
+    void runTest() override {
+        // Test isKnownRawAudioExtension
+
+        // Positive cases (known raw extensions)
+        ASSERT_TRUE(track::isKnownRawAudioExtension(".ulaw"), ".ulaw should be known raw extension");
+        ASSERT_TRUE(track::isKnownRawAudioExtension(".ULAW"), ".ULAW should be case-insensitive");
+        ASSERT_TRUE(track::isKnownRawAudioExtension("test.ulaw"), "test.ulaw should be recognized");
+        ASSERT_TRUE(track::isKnownRawAudioExtension("/path/to/file.pcm"), "path with .pcm should be recognized");
+        ASSERT_TRUE(track::isKnownRawAudioExtension(".722"), ".722 should be recognized");
+        ASSERT_TRUE(track::isKnownRawAudioExtension(".f64be"), ".f64be should be recognized");
+
+        // Negative cases (non-raw extensions)
+        ASSERT_FALSE(track::isKnownRawAudioExtension(".mp3"), ".mp3 is not raw audio");
+        ASSERT_FALSE(track::isKnownRawAudioExtension(".flac"), ".flac is not raw audio");
+        ASSERT_FALSE(track::isKnownRawAudioExtension(".wav"), ".wav is not raw audio (it is a container)");
+        ASSERT_FALSE(track::isKnownRawAudioExtension("test.txt"), ".txt is not raw audio");
+
+        // Edge cases
+        ASSERT_FALSE(track::isKnownRawAudioExtension(""), "Empty path should not be raw extension");
+        ASSERT_FALSE(track::isKnownRawAudioExtension("no_extension"), "Path without extension should not be raw");
+        ASSERT_FALSE(track::isKnownRawAudioExtension("."), "Path with only dot should not be raw");
+
+        // Test shouldCreateTagLibRefForPath
+
+        // Cases where it should return true (TagLib SHOULD be used)
+        ASSERT_TRUE(track::shouldCreateTagLibRefForPath("test.mp3"), "Should create TagLib ref for .mp3");
+        ASSERT_TRUE(track::shouldCreateTagLibRefForPath("test.flac"), "Should create TagLib ref for .flac");
+        ASSERT_TRUE(track::shouldCreateTagLibRefForPath("test.ogg"), "Should create TagLib ref for .ogg");
+
+        // Cases where it should return false (TagLib SHOULD NOT be used)
+        ASSERT_FALSE(track::shouldCreateTagLibRefForPath(""), "Should not create TagLib ref for empty path");
+        ASSERT_FALSE(track::shouldCreateTagLibRefForPath("test.pcm"), "Should not create TagLib ref for raw audio (.pcm)");
+        ASSERT_FALSE(track::shouldCreateTagLibRefForPath("test.alaw"), "Should not create TagLib ref for raw audio (.alaw)");
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    TestSuite suite("Track Utility Tests");
+    suite.addTest(std::make_unique<TrackUtilsTest>());
+
+    auto results = suite.runAll();
+    suite.printResults(results);
+
+    return suite.getFailureCount(results) > 0 ? 1 : 0;
+}


### PR DESCRIPTION
I have implemented unit tests for previously untested track utility functions.

Key changes:
- Refactored `isKnownRawAudioExtension` and `shouldCreateTagLibRefForPath` from an anonymous namespace in `src/track.cpp` to `public static` methods in the `track` class (`include/track.h`).
- Created a new test suite `tests/test_track_utils.cpp` using the project's `TestFramework`.
- Updated `tests/Makefile.am` to include the new test.

Verification:
- Verified the logic using a standalone mock-based compilation process since environment limitations prevented a full `make check`.
- Confirmed that the new tests correctly identify bugs by temporarily introducing broken logic.
- Received a positive code review confirming the correctness and completeness of the patch.

---
*PR created automatically by Jules for task [13022301388603116629](https://jules.google.com/task/13022301388603116629) started by @segin*