### PR TITLE
🧹 Remove unused <iostream> header in BoxParser.cpp

### DIFF
--- a/src/demuxer/iso/BoxParser.cpp
+++ b/src/demuxer/iso/BoxParser.cpp
@@ -14,7 +14,6 @@
 #include "demuxer/iso/ISODemuxer.h"
 #include "io/IOHandler.h"
 #include "debug.h"
-#include <iostream>
 #include <vector>
 #include <string>
 #include <cstdint>


### PR DESCRIPTION
🎯 **What:** Removed an unused `#include <iostream>` directive from `src/demuxer/iso/BoxParser.cpp`.
💡 **Why:** Including unused headers increases compilation time and pollutes the global namespace. `<iostream>` in particular includes many standard objects (`std::cout`, `std::cin`, etc.) which are not used in `BoxParser.cpp`.
✅ **Verification:** Verified that the code compiles successfully without the header, and ran `make check` to ensure all tests still pass and no regressions were introduced.
✨ **Result:** Improved compilation efficiency and code cleanliness for the `BoxParser.cpp` file.

---
*PR created automatically by Jules for task [18420901690582410624](https://jules.google.com/task/18420901690582410624) started by @segin*