### PR TITLE
🔒 Fix potential buffer overflow when formatting MD5 hashes

### DIFF
--- a/libs/util/md5main.c
+++ b/libs/util/md5main.c
@@ -85,7 +85,7 @@ do_test(void)
 	md5_append(&state, (const md5_byte_t *)test[i], strlen(test[i]));
 	md5_finish(&state, digest);
 	for (di = 0; di < 16; ++di)
-	    sprintf(hex_output + di * 2, "%02x", digest[di]);
+	    snprintf(hex_output + di * 2, 3, "%02x", digest[di]);
 	if (strcmp(hex_output, test[i + 1])) {
 	    printf("MD5 (\"%s\") = ", test[i]);
 	    puts(hex_output);


### PR DESCRIPTION
🎯 **What:** Replaced `sprintf` with `snprintf` when formatting hex representations of MD5 digests in `libs/util/md5main.c`.
⚠️ **Risk:** Although `hex_output` had correctly sized boundaries in standard use cases, using `sprintf` unconditionally to write formatted strings carries a risk of buffer overflows if unexpected lengths are processed or sizes later change, which could lead to application crashes or potentially arbitrary code execution.
🛡️ **Solution:** Used `snprintf` with a rigid output size of `3` bytes (2 characters + null terminator), explicitly enforcing that no iteration can write past expected limits. Verified file layout, compilation, and self-tests all pass successfully.

---
*PR created automatically by Jules for task [4206128272529965247](https://jules.google.com/task/4206128272529965247) started by @segin*