### PR TITLE
🧹 [inline TrueType::Done() cleanup]

### DIFF
--- a/include/truetype.h
+++ b/include/truetype.h
@@ -6,7 +6,14 @@
 class TrueType {
 public:
     static void Init();
-    static void Done();
+
+    /**
+     * @brief Shuts down the global FreeType library instance, releasing all resources.
+     *
+     * Should only be called after all `Font` objects have been destroyed.
+     */
+    static void Done() { FT_Done_FreeType(m_library); }
+
     static FT_Library getLibrary() { return m_library; }
 private:
     static FT_Library m_library;

--- a/src/truetype.cpp
+++ b/src/truetype.cpp
@@ -30,13 +30,6 @@ void TrueType::Init() {
 }
 
 /**
- * @brief Shuts down the global FreeType library instance, releasing all resources.
- *
- * Should only be called after all `Font` objects have been destroyed.
- */
-void TrueType::Done() { FT_Done_FreeType(m_library); }
-
-/**
  * @brief RAII wrapper that manages the lifetime of the global FreeType library.
  *
  * Its constructor calls `TrueType::Init()` and its destructor calls


### PR DESCRIPTION
🎯 **What:** Inlined the `TrueType::Done()` method and moved its documentation to the header file.
💡 **Why:** The function was doing only one thing (calling `FT_Done_FreeType(m_library)`). Moving it inline to the header saves a redundant function call definition and improves code health by keeping the class's API clearly documented and concise.
✅ **Verification:** Verified that the build passes and tests compile accurately after making the change. The FreeType functionality works precisely as it did before.
✨ **Result:** Cleaned up the `TrueType` implementation without altering its behavior, increasing maintainability.

---
*PR created automatically by Jules for task [8609506592336358470](https://jules.google.com/task/8609506592336358470) started by @segin*