### PR TITLE
⚡ [Performance Improvement] Document metadata map insert optimization

### DIFF
--- a/src/demuxer/MediaFactory.cpp
+++ b/src/demuxer/MediaFactory.cpp
@@ -198,6 +198,7 @@ ContentInfo MediaFactory::analyzeContent(const std::string& uri) {
         if (!content_result.mime_type.empty() && best_match.mime_type.empty()) {
             best_match.mime_type = content_result.mime_type;
         }
+        // Use map::insert for single tree traversal optimization
         best_match.metadata.insert(content_result.metadata.begin(), content_result.metadata.end());
     }
     


### PR DESCRIPTION
💡 **What:** Documented the use of map::insert instead of a find/operator[] loop.
🎯 **Why:** map::insert performs a single tree traversal.
📊 **Measured Improvement:** No functional changes, optimization was already present.

---
*PR created automatically by Jules for task [13644665767154217459](https://jules.google.com/task/13644665767154217459) started by @segin*