### PR TITLE
🧪 [Testing Improvement] Add explicit test coverage for BufferPool bad_alloc handling

### DIFF
--- a/tests/test_io_buffer_pool.cpp
+++ b/tests/test_io_buffer_pool.cpp
@@ -27,9 +27,23 @@ public:
         testLargeAllocation();
         testClear();
         testLimits();
+        testDirectAllocationFailure();
     }
 
 private:
+    void testDirectAllocationFailure() {
+        IOBufferPool& pool = IOBufferPool::getInstance();
+
+        // Request a ridiculously large size to trigger std::bad_alloc
+        // since it is > 1MB, shouldPool() returns false, and it does direct allocation.
+        // It will fail, catch bad_alloc, and return an empty Buffer.
+        size_t size = static_cast<size_t>(-1) - 1024;
+
+        IOBufferPool::Buffer buffer = pool.acquire(size);
+        ASSERT_NULL(buffer.data(), "Buffer data should be null after allocation failure");
+        ASSERT_EQUALS(static_cast<size_t>(0), buffer.size(), "Buffer size should be 0 after allocation failure");
+    }
+
     void testSingleton() {
         IOBufferPool& pool1 = IOBufferPool::getInstance();
         IOBufferPool& pool2 = IOBufferPool::getInstance();


### PR DESCRIPTION
🎯 **What:** The `BufferPool::acquire()` function has a catch block that intercepts `std::bad_alloc` when `!shouldPool(size)` evaluates to true (i.e. very large memory requests). This branch lacked explicit test coverage.

📊 **Coverage:** A new test case `testDirectAllocationFailure` was introduced to `tests/test_io_buffer_pool.cpp` that guarantees traversal of this code path. By requesting an allocation of `SIZE_MAX - 1024`, the direct allocation logic is executed. Since the operating system cannot satisfy this request, `std::bad_alloc` is reliably thrown and caught, yielding a fallback to returning an empty `Buffer`.

✨ **Result:** Test coverage improved for out-of-memory handling scenarios, providing higher confidence that allocation failures are handled cleanly without runtime crashes.

---
*PR created automatically by Jules for task [16666524181062387177](https://jules.google.com/task/16666524181062387177) started by @segin*