### PR TITLE
🧹 [Code Health] Replace std::cerr with Debug::log in ChainedStream

### DIFF
--- a/src/demuxer/ChainedStream.cpp
+++ b/src/demuxer/ChainedStream.cpp
@@ -121,7 +121,7 @@ bool ChainedStream::openNextTrack()
         m_current_track_index++;
         return m_current_stream != nullptr;
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream: Failed to open track " << m_paths[m_current_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream: Failed to open track ", m_paths[m_current_track_index], ": ", e.what());
         m_current_stream.reset();
         return false;
     }
@@ -278,7 +278,7 @@ void ChainedStream::seekTo(unsigned long pos)
     try {
         m_current_stream = MediaFile::open(m_paths[target_track_index]);
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream::seekTo: Failed to open track " << m_paths[target_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream::seekTo: Failed to open track ", m_paths[target_track_index], ": ", e.what());
         m_current_stream.reset();
         m_eof = true; // Can't play anymore.
         return;


### PR DESCRIPTION
🎯 **What:** Replaced `std::cerr` with `Debug::log` in `ChainedStream::seekTo` and `ChainedStream::openNextTrack` within `src/demuxer/ChainedStream.cpp`.
💡 **Why:** This improves code health by consistently using the application's logging framework instead of raw console output, providing better predictability, formatting, and control over application traces.
✅ **Verification:** Verified the code changes by compiling `ChainedStream.o` successfully and evaluating the code logic (which has purely logging side effects and retains functional equivalence).
✨ **Result:** Enhanced uniformity across the codebase for error reporting and debugging.

---
*PR created automatically by Jules for task [17741565555794471096](https://jules.google.com/task/17741565555794471096) started by @segin*