### PR TITLE
🧹 [Remove deprecated Audio::unlock and Audio::lock methods]

### DIFF
--- a/include/audio.h
+++ b/include/audio.h
@@ -30,8 +30,6 @@ public:
     ~Audio();
 
     void play(bool go);
-    void lock(void);
-    void unlock(void);
     bool isFinished() const;
     std::unique_ptr<Stream> setStream(std::unique_ptr<Stream> new_stream);
 

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -169,22 +169,6 @@ bool Audio::isFinished() const
 }
 
 /**
- * @brief Locks the audio device using the SDL_LockAudio function.
- * @deprecated This is a legacy function. Modern thread safety is handled by std::mutex.
- */
-void Audio::lock(void) {
-    SDL_LockAudio();
-}
-
-/**
- * @brief Unlocks the audio device using the SDL_UnlockAudio function.
- * @deprecated This is a legacy function. Modern thread safety is handled by std::mutex.
- */
-void Audio::unlock(void) {
-    SDL_UnlockAudio();
-}
-
-/**
  * @brief Clears the decoded audio buffer and resets the samples-played counter.
  *
  * Thread-safe; acquires `m_buffer_mutex` internally.


### PR DESCRIPTION
🎯 What: Removed the deprecated `Audio::unlock` and `Audio::lock` methods from `src/audio.cpp` and `include/audio.h`.
💡 Why: These methods were legacy wrappers for SDL audio locking and were explicitly marked as deprecated in favor of modern `std::mutex` usage. Removing them improves maintainability by clearing out dead code and preventing confusion about the application's synchronization strategy.
✅ Verification: Compiled successfully using `./autogen.sh && ./configure && make -j$(nproc)` and verified test integrity via `make check`.
✨ Result: Cleaner `Audio` class API that better reflects the modern standard library concurrency utilities in use.

---
*PR created automatically by Jules for task [11148249137188369323](https://jules.google.com/task/11148249137188369323) started by @segin*