### PR TITLE
🧹 [code health improvement] Replace std::cerr with Debug::log in ChainedStream.cpp

### DIFF
--- a/src/demuxer/ChainedStream.cpp
+++ b/src/demuxer/ChainedStream.cpp
@@ -121,7 +121,7 @@ bool ChainedStream::openNextTrack()
         m_current_track_index++;
         return m_current_stream != nullptr;
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream: Failed to open track " << m_paths[m_current_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream: Failed to open track ", m_paths[m_current_track_index], ": ", e.what());
         m_current_stream.reset();
         return false;
     }
@@ -278,7 +278,7 @@ void ChainedStream::seekTo(unsigned long pos)
     try {
         m_current_stream = MediaFile::open(m_paths[target_track_index]);
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream::seekTo: Failed to open track " << m_paths[target_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream::seekTo: Failed to open track ", m_paths[target_track_index], ": ", e.what());
         m_current_stream.reset();
         m_eof = true; // Can't play anymore.
         return;


### PR DESCRIPTION
🎯 **What:** Replaced raw `std::cerr` calls with the `Debug::log` facility in `src/demuxer/ChainedStream.cpp`.
💡 **Why:** To improve code health, consistency with the rest of the codebase, and to allow for proper log channel filtering.
✅ **Verification:** Recompiled the `test_demuxer_unit` module and ran the full `make check` suite, ensuring all tests pass, verifying the syntactic and linker correctness of the change.
✨ **Result:** Better integration with the built-in debugging/logging system.

---
*PR created automatically by Jules for task [2169020053321164073](https://jules.google.com/task/2169020053321164073) started by @segin*