### PR TITLE
🧹 [Code Health] Replace std::cerr with Debug::log in ChainedStream

### DIFF
--- a/src/demuxer/ChainedStream.cpp
+++ b/src/demuxer/ChainedStream.cpp
@@ -121,7 +121,7 @@ bool ChainedStream::openNextTrack()
         m_current_track_index++;
         return m_current_stream != nullptr;
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream: Failed to open track " << m_paths[m_current_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream: Failed to open track ", m_paths[m_current_track_index], ": ", e.what());
         m_current_stream.reset();
         return false;
     }
@@ -278,7 +278,7 @@ void ChainedStream::seekTo(unsigned long pos)
     try {
         m_current_stream = MediaFile::open(m_paths[target_track_index]);
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream::seekTo: Failed to open track " << m_paths[target_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream::seekTo: Failed to open track ", m_paths[target_track_index], ": ", e.what());
         m_current_stream.reset();
         m_eof = true; // Can't play anymore.
         return;


### PR DESCRIPTION
🎯 **What:** Replaced `std::cerr` usage with `Debug::log` in `src/demuxer/ChainedStream.cpp` within both `openNextTrack` and `seekTo`.
💡 **Why:** To improve code health, ensure all logging follows the standard codebase facility, and increase consistency across the modules.
✅ **Verification:** Verified via `make check` passing existing IOHandler and Demuxer tests perfectly.
✨ **Result:** Enhanced logging uniformity and maintainability.

---
*PR created automatically by Jules for task [7229908448467145273](https://jules.google.com/task/7229908448467145273) started by @segin*