### PR TITLE
🧹 Refactor percentEncodeW attribute

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -46,9 +46,7 @@ typedef struct tagTHREADNAME_INFO {
  * @param input The wide string to encode.
  * @return The percent-encoded wide string.
  */
-static std::wstring percentEncodeW(const std::wstring &input)
-    __attribute__((unused));
-static std::wstring percentEncodeW(const std::wstring &input) {
+[[maybe_unused]] static std::wstring percentEncodeW(const std::wstring &input) {
   std::wstringstream encoded;
   for (wchar_t wc : input) {
     if (iswalnum(wc) || wc == L'-' || wc == L'.' || wc == L'_' || wc == L'~') {


### PR DESCRIPTION
🎯 **What:** Replaced the non-standard `__attribute__((unused))` with the standard C++17 `[[maybe_unused]]` attribute on the `percentEncodeW` function in `src/system.cpp`. Removed the redundant forward declaration and directly applied the attribute to the function definition.
💡 **Why:** `percentEncodeW` is only used inside the `System::ipcWndProc` function, which is conditionally compiled under `#ifdef _WIN32`. On non-Windows platforms, it's effectively unused, triggering compiler warnings. The standard C++17 `[[maybe_unused]]` attribute is the modern and preferred way to handle this, replacing the older GCC-specific syntax. This improves the codebase's adherence to modern C++ standards and enhances maintainability.
✅ **Verification:** Verified by compiling the codebase (`make`) and running the test suite (`make check`) to ensure no new errors or warnings were introduced and that existing functionality is preserved.
✨ **Result:** A cleaner, more modern, and standard-compliant function definition.

---
*PR created automatically by Jules for task [13546888722324879485](https://jules.google.com/task/13546888722324879485) started by @segin*