### PR TITLE
🧹 Replace std::cerr with Debug::log in ChainedStream

### DIFF
--- a/src/demuxer/ChainedStream.cpp
+++ b/src/demuxer/ChainedStream.cpp
@@ -121,7 +121,7 @@ bool ChainedStream::openNextTrack()
         m_current_track_index++;
         return m_current_stream != nullptr;
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream: Failed to open track " << m_paths[m_current_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream: Failed to open track ", m_paths[m_current_track_index], ": ", e.what());
         m_current_stream.reset();
         return false;
     }
@@ -278,7 +278,7 @@ void ChainedStream::seekTo(unsigned long pos)
     try {
         m_current_stream = MediaFile::open(m_paths[target_track_index]);
     } catch (const std::exception& e) {
-        std::cerr << "ChainedStream::seekTo: Failed to open track " << m_paths[target_track_index] << ": " << e.what() << std::endl;
+        Debug::log("demuxer", "ChainedStream::seekTo: Failed to open track ", m_paths[target_track_index], ": ", e.what());
         m_current_stream.reset();
         m_eof = true; // Can't play anymore.
         return;


### PR DESCRIPTION
🎯 **What:** Replaced raw `std::cerr` logging with the application's built-in `Debug::log` facility in `src/demuxer/ChainedStream.cpp`.
💡 **Why:** To improve code health, ensure logging consistency across the application, and direct demuxer errors correctly to the `"demuxer"` log channel instead of bypassing the logging system.
✅ **Verification:** Verified the code compiles successfully (`./autogen.sh && ./configure --enable-test-harness && make -j$(nproc)`) and the full test suite runs without introducing any regressions (`make check`).
✨ **Result:** A cleaner codebase matching the project's internal logging standards.

---
*PR created automatically by Jules for task [5123633320596143652](https://jules.google.com/task/5123633320596143652) started by @segin*