### PR TITLE
🧹 [code health improvement] Use member initializer list for track metadata strings

### DIFF
--- a/src/track.cpp
+++ b/src/track.cpp
@@ -137,11 +137,12 @@ bool track::shouldCreateTagLibRefForPath(const TagLib::String& path)
  * @param extinf_duration Duration in seconds from EXTINF (0 means unknown).
  */
 track::track(const TagLib::String& a_FilePath, const TagLib::String& extinf_artist, const TagLib::String& extinf_title, long extinf_duration)
-    : m_FilePath(a_FilePath), m_Len(extinf_duration)
+    : m_Artist(extinf_artist),
+      m_Title(extinf_title),
+      m_FilePath(a_FilePath),
+      m_Len(extinf_duration)
 {
     // Prioritize EXTINF data if provided
-    if (!extinf_artist.isEmpty()) m_Artist = extinf_artist;
-    if (!extinf_title.isEmpty()) m_Title = extinf_title;
 
     // Then attempt to load tags from TagLib, which will fill in missing info
     // and create m_FileRef if not already done.


### PR DESCRIPTION
🎯 **What:** The assignments of `m_Artist` and `m_Title` strings inside the `track` constructor have been moved to the constructor's initialization list.

💡 **Why:** Using the member initializer list to copy-construct these strings directly avoids the overhead of default-constructing them (which creates null TagLib strings) and subsequently copy-assigning them in the body, providing a minor performance and stylistic code health improvement.

✅ **Verification:** Verified safe by running `make check`. The logic continues to handle empty strings correctly. 

✨ **Result:** A cleaner constructor and a minor optimization by removing unnecessary default string creations.

---
*PR created automatically by Jules for task [9576515798141698553](https://jules.google.com/task/9576515798141698553) started by @segin*