### PR TITLE
🧹 Mark unused name parameter in ChainedStream::open with [[maybe_unused]]

### DIFF
--- a/src/demuxer/ChainedStream.cpp
+++ b/src/demuxer/ChainedStream.cpp
@@ -134,7 +134,7 @@ bool ChainedStream::openNextTrack()
  * support being "re-opened" with a single file path. This method does nothing.
  * @param name This parameter is ignored.
  */
-void ChainedStream::open(TagLib::String name)
+void ChainedStream::open([[maybe_unused]] TagLib::String name)
 {
     // This is a no-op for ChainedStream as it's initialized with a list of paths.
     // The name parameter is ignored.


### PR DESCRIPTION
🎯 **What:** Marked the unused `name` parameter in `ChainedStream::open` with `[[maybe_unused]]`.
💡 **Why:** `ChainedStream` inherits `Stream::open(TagLib::String name)`, but implements it as a no-op since it initializes with a list of paths. The `[[maybe_unused]]` attribute clarifies developer intent and prevents compiler warnings about the unused parameter.
✅ **Verification:** Compiled the project and ran the test suite (`make check`) successfully. The change is limited to attribute addition and guarantees no functional regressions.
✨ **Result:** Improved code cleanliness and clear intent for unused inherited method parameters.

---
*PR created automatically by Jules for task [5879815699853478439](https://jules.google.com/task/5879815699853478439) started by @segin*