### PR TITLE
🧹 [code health improvement] Remove redundant std::cerr log in Playlist::addFile

### DIFF
--- a/src/playlist.cpp
+++ b/src/playlist.cpp
@@ -58,7 +58,6 @@ bool Playlist::addFile(TagLib::String path)
         return true;
     } catch (const std::exception& e) {
         Debug::log("playlist", "Playlist::addFile(): Failed to create track for ", path.to8Bit(true), ": ", e.what());
-        std::cerr << "Playlist::addFile(): Could not create track for " << path << ": " << e.what() << std::endl;
         return false;
     }
 }


### PR DESCRIPTION
🎯 **What:** Removed a duplicate `std::cerr` error log line in `Playlist::addFile`.
💡 **Why:** Consolidates logging output by relying solely on the application's standard `Debug::log` channel, eliminating a redundant console error print that was identical to the `Debug::log` call immediately preceding it. This improves code hygiene and maintainability.
✅ **Verification:** Compiled the application and successfully ran the `test_playlist_shuffle` and `test_playlist_load` test suites manually using `make -C tests test_playlist_shuffle test_playlist_load` to verify no functionality was broken.
✨ **Result:** Cleaner error handling block in `Playlist::addFile` with consolidated logging.

---
*PR created automatically by Jules for task [8744953918459407161](https://jules.google.com/task/8744953918459407161) started by @segin*