### PR TITLE
🧪 [testing improvement] Add tests for FFT mode setting and getters

### DIFF
--- a/include/core/fft.h
+++ b/include/core/fft.h
@@ -25,6 +25,10 @@
 #ifndef FFT_H
 #define FFT_H
 
+#include <vector>
+#include <complex>
+#include <string>
+
 namespace PsyMP3 {
 namespace Core {
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3807,6 +3807,12 @@ test_base64_unit_LDADD = \
 	$(top_builddir)/src/debug.o \
 	$(AM_LDFLAGS)
 
+check_PROGRAMS += test_fft_mode
+test_fft_mode_SOURCES = test_fft_mode.cpp
+test_fft_mode_LDADD = \
+	libtest_utilities.a \
+	../src/core/libpsymp3-core.a
+
 # Run all check programs
 TESTS = $(check_PROGRAMS)
 

--- a/tests/test_fft_mode.cpp
+++ b/tests/test_fft_mode.cpp
@@ -1,0 +1,62 @@
+/*
+ * test_fft_mode.cpp - Unit tests for FFT mode setting and getting
+ * This file is part of PsyMP3.
+ *
+ * PsyMP3 is free software. You may redistribute and/or modify it under
+ * the terms of the ISC License <https://opensource.org/licenses/ISC>
+ */
+
+#include "test_framework.h"
+#include "core/fft.h"
+
+using namespace PsyMP3::Core;
+using namespace TestFramework;
+
+class FFTModeTest : public TestCase {
+public:
+    FFTModeTest() : TestCase("FFTModeTest") {}
+
+protected:
+    void runTest() override {
+        // FFT size must be a power of 2
+        FFT fft(2);
+
+        // Test Original mode
+        fft.setFFTMode(FFTMode::Original);
+        ASSERT_TRUE(fft.getFFTMode() == FFTMode::Original, "getFFTMode should return Original");
+        ASSERT_TRUE(fft.getFFTModeName() == "mat-og", "getFFTModeName should return mat-og");
+
+        // Test Optimized mode
+        fft.setFFTMode(FFTMode::Optimized);
+        ASSERT_TRUE(fft.getFFTMode() == FFTMode::Optimized, "getFFTMode should return Optimized");
+        ASSERT_TRUE(fft.getFFTModeName() == "vibe-1", "getFFTModeName should return vibe-1");
+
+        // Test NeomatIn mode
+        fft.setFFTMode(FFTMode::NeomatIn);
+        ASSERT_TRUE(fft.getFFTMode() == FFTMode::NeomatIn, "getFFTMode should return NeomatIn");
+        ASSERT_TRUE(fft.getFFTModeName() == "neomat-in", "getFFTModeName should return neomat-in");
+
+        // Test NeomatOut mode
+        fft.setFFTMode(FFTMode::NeomatOut);
+        ASSERT_TRUE(fft.getFFTMode() == FFTMode::NeomatOut, "getFFTMode should return NeomatOut");
+        ASSERT_TRUE(fft.getFFTModeName() == "neomat-out", "getFFTModeName should return neomat-out");
+    }
+};
+
+int main() {
+    try {
+        FFTModeTest test;
+        TestCaseInfo info = test.run();
+
+        if (info.result != TestResult::PASSED) {
+            std::cerr << "Test failed: " << info.failure_message << std::endl;
+            return 1;
+        }
+
+        std::cout << "All FFT mode tests passed." << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Unhandled exception: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
🎯 **What:** The task required adding tests for the `setFFTMode` logic in `src/core/fft.cpp`, specifically targeting `setFFTMode`, `getFFTMode`, and `getFFTModeName`.
📊 **Coverage:** A new test case `tests/test_fft_mode.cpp` was written covering all valid enum cases (`FFTMode::Original`, `FFTMode::Optimized`, `FFTMode::NeomatIn`, `FFTMode::NeomatOut`). The test ensures these getters properly reflect state modifications. I also caught and resolved a missing `<complex>` header that caused build issues when including `fft.h` in isolation. 
✨ **Result:** Enhanced unit test coverage and confidence in the FFT codebase's state control logic. Tests were integrated into `make check`.

---
*PR created automatically by Jules for task [2899678280063234222](https://jules.google.com/task/2899678280063234222) started by @segin*