### PR TITLE
🧪 [testing improvement] Add test for OggFLACPassthroughCodec exception handling

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -876,12 +876,8 @@ test_ogg_fuzzing_LDADD = libtest_utilities.a \
 	$(top_builddir)/src/tag/libpsymp3-tag.a \
 	$(top_builddir)/src/core/utility/libpsymp3-core-utility.a \
 	$(OGG_LIBS) \
-	$(SDL_LIBS) \
-	$(TAGLIB_LIBS) \
-	$(ZLIB_LIBS) \
-	$(FREETYPE_LIBS) \
-	$(DBUS_LIBS) \
-	$(OPUS_LIBS)
+	$(COMMON_CODEC_LIBS) \
+	$(AM_LDFLAGS)
 
 test_ogg_multiplexed_seeking_SOURCES = test_ogg_multiplexed_seeking.cpp
 test_ogg_multiplexed_seeking_LDADD = libtest_utilities.a \
@@ -893,8 +889,11 @@ test_ogg_multiplexed_seeking_LDADD = libtest_utilities.a \
 	../src/io/libpsymp3-io.a \
 	../src/debug.o \
 	../src/core/libpsymp3-core.a \
+	$(top_builddir)/src/stream.o \
+	$(top_builddir)/src/track.o \
 	$(top_builddir)/src/core/libpsymp3-core.a \
 	$(top_builddir)/src/tag/libpsymp3-tag.a \
+	$(top_builddir)/src/demuxer/raw/libpsymp3-demuxer-raw.a \
 	$(top_builddir)/src/core/utility/libpsymp3-core-utility.a \
 	$(OGG_LIBS) \
 	$(SDL_LIBS) \
@@ -1112,6 +1111,7 @@ test_ogg_seeking_algorithms_LDADD = libtest_utilities.a \
 check_PROGRAMS += test_ogg_error_handling
 test_ogg_error_handling_SOURCES = test_ogg_error_handling.cpp
 test_ogg_error_handling_LDADD = libtest_utilities.a \
+	$(FULL_CODEC_LIBS) \
 	../src/demuxer/ogg/libpsymp3-demuxer-ogg.a \
 	../src/demuxer/libpsymp3-demuxer.a \
 	../src/tag/libpsymp3-tag.a \

--- a/tests/test_ogg_error_handling.cpp
+++ b/tests/test_ogg_error_handling.cpp
@@ -103,6 +103,28 @@ bool testMalformedSignatures() {
     return true;
 }
 
+bool testOggFLACExceptionHandling() {
+    std::cout << "Testing OggFLACPassthroughCodec exception handling..." << std::endl;
+
+    StreamInfo info;
+    info.codec_name = "flac";
+    // Provide an invalid sample rate to force initialization to fail.
+    // The maximum sample rate permitted by RFC 9639 is 1048575 Hz.
+    info.sample_rate = 2000000;
+    info.codec_data = {0x00, 0x01, 0x02};
+
+    OggFLACPassthroughCodec codec(info);
+    bool result = codec.initialize();
+
+    // Depending on the NativeFLACCodec implementation, it might throw an exception
+    // that OggFLACPassthroughCodec catches, or it might just return false.
+    // In either case, the passthrough codec should return false and not crash.
+    ASSERT(!result, "Should return false when underlying FLACCodec initialization fails");
+
+    std::cout << "  ✓ Passed" << std::endl;
+    return true;
+}
+
 int main() {
     std::cout << "Running OggDemuxer Error Handling Tests..." << std::endl;
     std::cout << "===========================================" << std::endl;
@@ -115,6 +137,7 @@ int main() {
     if (testInvalidGranuleHandling()) passed++; total++;
     if (testOverflowProtection()) passed++; total++;
     if (testMalformedSignatures()) passed++; total++;
+    if (testOggFLACExceptionHandling()) passed++; total++;
     
     std::cout << std::endl;
     if (passed == total) {


### PR DESCRIPTION
🎯 **What:** Improved test coverage for `OggFLACPassthroughCodec::initialize` in `src/codecs/OggCodecs.cpp` by validating the behavior when the underlying codec throws an exception or fails initialization due to malformed data.
📊 **Coverage:** Added `testOggFLACExceptionHandling` to `tests/test_ogg_error_handling.cpp` which simulates an invalid sample rate for FLAC initialization, verifying the outer codec correctly returns false and handles the failure gracefully. Updated `tests/Makefile.am` to link necessary dependencies (`FULL_CODEC_LIBS` and `COMMON_CODEC_LIBS`) for proper test compilation.
✨ **Result:** Enhanced error handling test coverage for Ogg demuxing.

---
*PR created automatically by Jules for task [3976644242601386341](https://jules.google.com/task/3976644242601386341) started by @segin*