### PR TITLE
🧹 [simplify MergedID3Tag::hasTag logic]

### DIFF
--- a/src/tag/MergedID3Tag.cpp
+++ b/src/tag/MergedID3Tag.cpp
@@ -158,13 +158,7 @@ std::map<std::string, std::string> MergedID3Tag::getAllTags() const {
 
 bool MergedID3Tag::hasTag(const std::string& key) const {
     // Check both tags
-    if (m_v2 && m_v2->hasTag(key)) {
-        return true;
-    }
-    if (m_v1 && m_v1->hasTag(key)) {
-        return true;
-    }
-    return false;
+    return (m_v2 && m_v2->hasTag(key)) || (m_v1 && m_v1->hasTag(key));
 }
 
 size_t MergedID3Tag::pictureCount() const {


### PR DESCRIPTION
🎯 **What:** Simplified the boolean logic in `MergedID3Tag::hasTag` by replacing redundant `if` statements with a single logical OR return statement.
💡 **Why:** This improves maintainability and readability by removing unreachable code paths after an unconditional return in the `if` statement, while preserving functional correctness and short-circuiting behavior.
✅ **Verification:** The change was verified by compiling the modified file within a standalone test harness that mocked the necessary `Tag` interfaces and confirmed no syntax or logic errors were introduced.
✨ **Result:** Cleaner, more idiomatic C++ code for the tag merging logic.

---
*PR created automatically by Jules for task [1554613239247978054](https://jules.google.com/task/1554613239247978054) started by @segin*