### PR TITLE
🔒 Restrict System storage path permissions to 0700

### DIFF
--- a/src/system.cpp
+++ b/src/system.cpp
@@ -517,7 +517,7 @@ bool System::createStoragePath() {
          (GetLastError() == ERROR_ALREADY_EXISTS);
 #else
   // mkdir returns 0 on success.
-  return mkdir(path.toCString(true), 0755) == 0 || (errno == EEXIST);
+  return mkdir(path.toCString(true), 0700) == 0 || (errno == EEXIST);
 #endif
 }
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is that `System::createStoragePath()` was invoking `mkdir` with `0755` permissions for user configuration and storage directories.
⚠️ **Risk:** By setting permissions to `0755`, other users on the system could potentially read the contents of the configuration directories, putting sensitive user data or configuration at risk of unauthorized access.
🛡️ **Solution:** The permissions argument passed to `mkdir` has been restricted to `0700`, ensuring the directory is only readable, writable, and executable by the owner.

---
*PR created automatically by Jules for task [15930402972452581726](https://jules.google.com/task/15930402972452581726) started by @segin*