### PR TITLE
🧹 [code health improvement] Simplify hasTag logic in MergedID3Tag

### DIFF
--- a/src/tag/MergedID3Tag.cpp
+++ b/src/tag/MergedID3Tag.cpp
@@ -158,13 +158,7 @@ std::map<std::string, std::string> MergedID3Tag::getAllTags() const {
 
 bool MergedID3Tag::hasTag(const std::string& key) const {
     // Check both tags
-    if (m_v2 && m_v2->hasTag(key)) {
-        return true;
-    }
-    if (m_v1 && m_v1->hasTag(key)) {
-        return true;
-    }
-    return false;
+    return (m_v2 && m_v2->hasTag(key)) || (m_v1 && m_v1->hasTag(key));
 }
 
 size_t MergedID3Tag::pictureCount() const {


### PR DESCRIPTION
🎯 **What:** The boolean logic in `MergedID3Tag::hasTag` was simplified from multiple redundant `if` statements to a single inline boolean expression returning the evaluation.
💡 **Why:** This improves the code health by increasing readability, removing unreachable code paths, and using short-circuit logic more idiomatically.
✅ **Verification:** Compiled the module individually and ran `test_tag_unit` test suite; all 75 tests passed, confirming functional equivalence.
✨ **Result:** A more robust and cleaner implementation of the fallback logic check for ID3 tag keys.

---
*PR created automatically by Jules for task [1134906521254980838](https://jules.google.com/task/1134906521254980838) started by @segin*