### PR TITLE
🧹 [Refactor IEEE 80-bit float conversion using std::ldexp]

### DIFF
--- a/src/demuxer/ChunkDemuxer.cpp
+++ b/src/demuxer/ChunkDemuxer.cpp
@@ -626,8 +626,7 @@ double ChunkDemuxer::ieee80ToDouble(const uint8_t ieee80[10]) const {
     }
     
     // Convert to double
-    double result = static_cast<double>(mantissa) / (1ULL << 63);
-    result *= std::pow(2.0, static_cast<int>(exponent) - 16383);
+    double result = std::ldexp(static_cast<double>(mantissa), exponent - 16383 - 63);
     
     return sign ? -result : result;
 }


### PR DESCRIPTION
🎯 **What:** Refactored the custom IEEE 80-bit float to `double` conversion routine in `ChunkDemuxer::ieee80ToDouble` to use `std::ldexp`.
💡 **Why:** Using `std::ldexp` from the standard `<cmath>` library is safer, cleaner, and avoids potential intermediate precision loss caused by `std::pow` and integer division scaling factors when calculating floating-point mantissa and exponents. It avoids needing to pull in a large external dependency for a single 10-byte conversion routine.
✅ **Verification:** Verified math equivalence mathematically and via isolated ad-hoc tests proving `std::ldexp` produces identical output. Confirmed `ChunkDemuxer.o` compiles cleanly in the main build chain.
✨ **Result:** Improved code readability, safety, and health by utilizing standard library functionality instead of custom floating point arithmetic reconstruction.

---
*PR created automatically by Jules for task [3068015473548146780](https://jules.google.com/task/3068015473548146780) started by @segin*