### PR TITLE
🧹 Improve distfiles fetching system in `util/build-deps.sh`

### DIFF
--- a/util/build-deps.sh
+++ b/util/build-deps.sh
@@ -114,6 +114,22 @@ clean_workdir() {
 
 # dist-related functions
 
+
+fetch_url() {
+	local url="$1"
+	local out="$2"
+	if command -v curl >/dev/null 2>&1; then
+		curl -f -L -C - -o "$out" "$url"
+	elif command -v wget >/dev/null 2>&1; then
+		wget -c -O "$out" "$url"
+	elif command -v fetch >/dev/null 2>&1; then
+		fetch -o "$out" "$url"
+	else
+		notice "No download tool found. Please install curl, wget, or fetch."
+		return 1
+	fi
+}
+
 distfiles_check() { # does the distfile exist and is it valid?
 	package=$1
 	package_check ${package}
@@ -171,7 +187,10 @@ distfiles_fetch () {
 
 	# If the file exists but didn't pass check, or doesn't exist, we download it using -c (continue)
 	notice "Fetching for ${package}-${DISTVERS[$package]}"
-	wget -c -O ${distfile} ${DISTS[$package]}
+	if ! fetch_url "${DISTS[$package]}" "${distfile}"; then
+		notice "Failed to download ${package}-${DISTVERS[$package]}! Bailing!"
+		exit 1
+	fi
 
 	if distfiles_sum MD5 ${package} && distfiles_sum SHA256 ${package}; then
 		return 0


### PR DESCRIPTION
🛠️ What: Introduced a `fetch_url` function to `util/build-deps.sh` and updated `distfiles_fetch` to use it.
💡 Why: The dependency fetching script was tightly coupled to `wget`. Using a fallback mechanism ensures broader compatibility across POSIX systems (e.g., macOS often defaults to `curl`, FreeBSD uses `fetch`). It also properly surfaces failures if a URL isn't found (e.g., HTTP 404).
✅ Verification: Tested the updated `build-deps.sh` locally with `zsh`, confirming it successfully attempts `curl` and accurately fails out if a 404 page is encountered instead of swallowing the error.

---
*PR created automatically by Jules for task [4133156286357211395](https://jules.google.com/task/4133156286357211395) started by @segin*