### PR TITLE
⚡ [Optimize IOBufferPool eviction map lookups]

### DIFF
--- a/src/io/BufferPool.cpp
+++ b/src/io/BufferPool.cpp
@@ -683,7 +683,13 @@ void IOBufferPool::optimizeAllocationPatterns() {
     Debug::log("memory", "BufferPool::optimizeAllocationPatterns() - Analyzing allocation patterns");
     
     // Analyze usage patterns and optimize pool configuration
-    std::vector<std::pair<size_t, double>> size_efficiency; // (size, efficiency_score)
+    struct EfficiencyData {
+        size_t size;
+        double efficiency;
+        PoolEntry* entry;
+    };
+    std::vector<EfficiencyData> size_efficiency;
+    size_efficiency.reserve(m_pools.size());
     
     for (const auto& pool_pair : m_pools) {
         const PoolEntry& entry = *pool_pair.second;
@@ -707,7 +713,7 @@ void IOBufferPool::optimizeAllocationPatterns() {
             efficiency_score *= (1.0 - static_cast<double>(memory_used) / m_current_pool_size);
         }
         
-        size_efficiency.emplace_back(buffer_size, efficiency_score);
+        size_efficiency.push_back({buffer_size, efficiency_score, pool_pair.second.get()});
         
         Debug::log("memory", "BufferPool::optimizeAllocationPatterns() - Size ", buffer_size, 
                   ": hit_rate=", hit_rate, ", memory_used=", memory_used, ", efficiency=", efficiency_score);
@@ -715,8 +721,8 @@ void IOBufferPool::optimizeAllocationPatterns() {
     
     // Sort by efficiency (lowest first for potential eviction)
     std::sort(size_efficiency.begin(), size_efficiency.end(),
-        [](const auto& a, const auto& b) {
-            return a.second < b.second;
+        [](const EfficiencyData& a, const EfficiencyData& b) {
+            return a.efficiency < b.efficiency;
         });
     
     // Evict inefficient buffer sizes if memory pressure is high
@@ -724,28 +730,26 @@ void IOBufferPool::optimizeAllocationPatterns() {
         size_t sizes_to_evict = size_efficiency.size() / 4; // Evict bottom 25%
         
         for (size_t i = 0; i < sizes_to_evict && i < size_efficiency.size(); ++i) {
-            size_t buffer_size = size_efficiency[i].first;
-            double efficiency = size_efficiency[i].second;
+            size_t buffer_size = size_efficiency[i].size;
+            double efficiency = size_efficiency[i].efficiency;
+            PoolEntry* entry = size_efficiency[i].entry;
             
             // Only evict if efficiency is very low
-            if (efficiency < 0.3) {
-                auto it = m_pools.find(buffer_size);
-                if (it != m_pools.end()) {
-                    // Evict half the buffers for this size
-                    std::lock_guard<std::mutex> entry_lock(it->second->mutex);
-                    if (!it->second->available_buffers.empty()) {
-                        size_t to_evict = it->second->available_buffers.size() / 2;
+            if (efficiency < 0.3 && entry != nullptr) {
+                // Evict half the buffers for this size
+                std::lock_guard<std::mutex> entry_lock(entry->mutex);
+                if (!entry->available_buffers.empty()) {
+                    size_t to_evict = entry->available_buffers.size() / 2;
 
-                        for (size_t j = 0; j < to_evict; ++j) {
-                            uint8_t* buffer = it->second->available_buffers.back();
-                            it->second->available_buffers.pop_back();
-                            delete[] buffer;
-                            m_current_pool_size.fetch_sub(buffer_size, std::memory_order_relaxed);
-                        }
-
-                        Debug::log("memory", "BufferPool::optimizeAllocationPatterns() - Evicted ",
-                                  to_evict, " buffers of size ", buffer_size, " (low efficiency: ", efficiency, ")");
+                    for (size_t j = 0; j < to_evict; ++j) {
+                        uint8_t* buffer = entry->available_buffers.back();
+                        entry->available_buffers.pop_back();
+                        delete[] buffer;
+                        m_current_pool_size.fetch_sub(buffer_size, std::memory_order_relaxed);
                     }
+
+                    Debug::log("memory", "BufferPool::optimizeAllocationPatterns() - Evicted ",
+                              to_evict, " buffers of size ", buffer_size, " (low efficiency: ", efficiency, ")");
                 }
             }
         }

--- a/tests/benchmark_buffer_pool_eviction.cpp
+++ b/tests/benchmark_buffer_pool_eviction.cpp
@@ -1,0 +1,99 @@
+#include <iostream>
+#include <vector>
+#include <chrono>
+#include <random>
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+
+struct PoolEntry {
+    std::mutex mutex;
+    std::vector<uint8_t*> available_buffers;
+    PoolEntry() {}
+};
+
+constexpr int ITERATIONS = 100000;
+
+double run_baseline(std::map<size_t, std::shared_ptr<PoolEntry>>& m_pools) {
+    auto start_baseline = std::chrono::high_resolution_clock::now();
+    size_t total_evicted_baseline = 0;
+    for (int it = 0; it < ITERATIONS; ++it) {
+        std::vector<std::pair<size_t, double>> size_efficiency;
+        for (const auto& pool_pair : m_pools) {
+            size_efficiency.emplace_back(pool_pair.first, (pool_pair.first % 10) / 10.0);
+        }
+
+        for (size_t i = 0; i < size_efficiency.size(); ++i) {
+            size_t buffer_size = size_efficiency[i].first;
+            double efficiency = size_efficiency[i].second;
+
+            if (efficiency < 0.3) {
+                auto pool_it = m_pools.find(buffer_size);
+                if (pool_it != m_pools.end()) {
+                    total_evicted_baseline++;
+                }
+            }
+        }
+    }
+    auto end_baseline = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(end_baseline - start_baseline).count();
+}
+
+double run_optimized(std::map<size_t, std::shared_ptr<PoolEntry>>& m_pools) {
+    auto start_optimized = std::chrono::high_resolution_clock::now();
+    size_t total_evicted_optimized = 0;
+    for (int it = 0; it < ITERATIONS; ++it) {
+        struct EfficiencyData {
+            size_t size;
+            double efficiency;
+            PoolEntry* entry;
+        };
+        std::vector<EfficiencyData> size_efficiency;
+        size_efficiency.reserve(m_pools.size());
+
+        for (const auto& pool_pair : m_pools) {
+            size_efficiency.push_back({pool_pair.first, (pool_pair.first % 10) / 10.0, pool_pair.second.get()});
+        }
+
+        for (size_t i = 0; i < size_efficiency.size(); ++i) {
+            size_t buffer_size = size_efficiency[i].size;
+            double efficiency = size_efficiency[i].efficiency;
+
+            if (efficiency < 0.3) {
+                if (size_efficiency[i].entry) {
+                    total_evicted_optimized++;
+                }
+            }
+        }
+    }
+    auto end_optimized = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(end_optimized - start_optimized).count();
+}
+
+int main() {
+    std::map<size_t, std::shared_ptr<PoolEntry>> m_pools;
+    for (size_t i = 1; i <= 1000; ++i) {
+        m_pools[i * 1024] = std::make_shared<PoolEntry>();
+        m_pools[i * 1024]->available_buffers.resize(10, nullptr);
+    }
+
+    // Warmup
+    run_baseline(m_pools);
+    run_optimized(m_pools);
+
+    double baseline_total = 0;
+    double optimized_total = 0;
+
+    for(int i=0; i<5; i++) {
+        baseline_total += run_baseline(m_pools);
+        optimized_total += run_optimized(m_pools);
+    }
+
+    std::cout << "Baseline (avg): " << (baseline_total / 5.0) << " us\n";
+    std::cout << "Optimized (avg): " << (optimized_total / 5.0) << " us\n";
+    std::cout << "Speedup: " << baseline_total / optimized_total << "x\n";
+
+    return 0;
+}


### PR DESCRIPTION
💡 **What:** Replaced an unnecessary `m_pools.find(buffer_size)` lookup inside the buffer pool eviction loop. We now cache a pointer to the `PoolEntry` directly in an `EfficiencyData` struct during the initial analysis loop, allowing O(1) direct access during the eviction step. We also call `.reserve()` on the vector to avoid reallocations.

🎯 **Why:** `optimizeAllocationPatterns` evaluates buffer statistics and evicts inefficient pools. The map `m_pools` was being iterated over to collect stats, and then looked up *again* using `m_pools.find()` for the eviction candidates. This resulted in an avoidable O(log N) overhead per eviction. Since the operation happens while holding an exclusive lock, preserving and using a raw pointer is safe and significantly faster.

📊 **Measured Improvement:** 
Created a standalone benchmark simulating the iteration over 1,000 pool entries, running 100,000 passes of eviction candidate selection. 
- **Baseline (avg):** 904,624 us
- **Optimized (avg):** 788,906 us
- **Speedup:** ~1.15x improvement on the optimization routine's inner loop.

---
*PR created automatically by Jules for task [17916129341220046635](https://jules.google.com/task/17916129341220046635) started by @segin*