### PR TITLE
🧹 Remove deprecated ID3v2 encodeUTF16_BOM function

### DIFF
--- a/include/tag/ID3v2Utils.h
+++ b/include/tag/ID3v2Utils.h
@@ -202,15 +202,6 @@ std::string decodeUTF16_BE(const uint8_t* data, size_t size);
 std::string decodeUTF16_LE(const uint8_t* data, size_t size);
 
 /**
- * @brief Encode UTF-8 to UTF-16 with BOM
- * 
- * @deprecated Use PsyMP3::Core::Utility::UTF8Util::toUTF16BOM() instead
- * @param text UTF-8 string
- * @return UTF-16 encoded bytes with BOM
- */
-std::vector<uint8_t> encodeUTF16_BOM(const std::string& text);
-
-/**
  * @brief Encode UTF-8 to UTF-16 Big Endian
  * 
  * @deprecated Use PsyMP3::Core::Utility::UTF8Util::toUTF16BE() instead

--- a/src/tag/ID3v2Utils.cpp
+++ b/src/tag/ID3v2Utils.cpp
@@ -144,12 +144,6 @@ std::string decodeUTF16_BOM(const uint8_t* data, size_t size) {
     return PsyMP3::Core::Utility::UTF8Util::fromUTF16BOM(data, size);
 }
 
-
-std::vector<uint8_t> encodeUTF16_BOM(const std::string& text) {
-    // Delegate to centralized UTF8Util
-    return PsyMP3::Core::Utility::UTF8Util::toUTF16BOM(text);
-}
-
 std::vector<uint8_t> encodeUTF16_BE(const std::string& text) {
     // Delegate to centralized UTF8Util
     return PsyMP3::Core::Utility::UTF8Util::toUTF16BE(text);
@@ -193,7 +187,7 @@ std::vector<uint8_t> encodeText(const std::string& text, TextEncoding encoding) 
         case TextEncoding::ISO_8859_1:
             return encodeISO8859_1(text);
         case TextEncoding::UTF_16_BOM:
-            return encodeUTF16_BOM(text);
+            return PsyMP3::Core::Utility::UTF8Util::toUTF16BOM(text);
         case TextEncoding::UTF_16_BE:
             return encodeUTF16_BE(text);
         case TextEncoding::UTF_8:


### PR DESCRIPTION
🎯 **What:** Replaced the usage of the deprecated `encodeUTF16_BOM` function in `src/tag/ID3v2Utils.cpp` with `PsyMP3::Core::Utility::UTF8Util::toUTF16BOM` and removed the deprecated function from both `include/tag/ID3v2Utils.h` and `src/tag/ID3v2Utils.cpp`.
💡 **Why:** This improves maintainability by consolidating Unicode handling into the centralized `UTF8Util` class and removing redundant, deprecated wrapper functions.
✅ **Verification:** Verified by searching the codebase for any remaining usages of `encodeUTF16_BOM` (none found) and performing a syntax check on the modified source file.
✨ **Result:** Reduced code duplication and cleaner API in the Tag subsystem.

---
*PR created automatically by Jules for task [6522413531612412015](https://jules.google.com/task/6522413531612412015) started by @segin*