### PR TITLE
🔒 [security fix] Fix buffer overflow and data leakage in dirname

### DIFF
--- a/libs/util/dirname.c
+++ b/libs/util/dirname.c
@@ -7,13 +7,13 @@
 #define DIRMAXLEN 1024
 
 char *dirname(const char *path) {
-  int l = 0;
+  size_t l = 0;
   static char dir[DIRMAXLEN];
   dir[0] = 0;
 #ifdef __WIN32__
-  for(l = strlen(path); path[l] != '\\' && l > 0; l--);
+  for(l = strlen(path); l > 0 && path[l] != '\\'; l--);
 #else
-  for(l = strlen(path); path[l] != '/' && l > 0; l--);
+  for(l = strlen(path); l > 0 && path[l] != '/'; l--);
 #endif
   if(l >= DIRMAXLEN) {
     errno = ENAMETOOLONG;
@@ -22,6 +22,6 @@ char *dirname(const char *path) {
   if(l == 0)
     return ".";
   strncpy(dir, path, l);
+  dir[l] = '\0';
   return dir;
 }
-


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability in the custom `dirname` implementation in `libs/util/dirname.c`.
⚠️ **Risk:** The previous implementation used `strncpy` without explicit null termination, which could lead to data leakage from previous uses of the static buffer. Additionally, the use of `int` for the length counter could potentially lead to integer overflows on very large input strings.
🛡️ **Solution:**
- Changed the type of the length counter `l` from `int` to `size_t` for better compatibility with large strings.
- Added explicit null termination `dir[l] = '\0'` after the `strncpy` call to ensure the buffer is always safe to use as a string.
- Reordered the loop condition to check the index bounds before accessing the path character.

---
*PR created automatically by Jules for task [14719587152600548555](https://jules.google.com/task/14719587152600548555) started by @segin*