### PR TITLE
🧹 Remove redundant if conditions in LZ77 decompression

### DIFF
--- a/src/core/compression/LZ77.cpp
+++ b/src/core/compression/LZ77.cpp
@@ -95,7 +95,6 @@ std::vector<uint8_t> LZ77Decompressor::decompress(const uint8_t* data, size_t si
     size_t cursor = 0;
 
     while (cursor < size) {
-        if (cursor >= size) break;
         uint8_t flags = data[cursor++];
         
         for (int i = 0; i < 8 && cursor < size; ++i) {
@@ -135,7 +134,6 @@ std::vector<uint8_t> LZ77Decompressor::decompress(const uint8_t* data, size_t si
                 }
             } else {
                 // Literal
-                if (cursor >= size) break; // Should effectively not happen if logic correct
                 output.push_back(data[cursor++]);
             }
             


### PR DESCRIPTION
### 🧹 Code Health Improvement: Remove redundant if conditions in LZ77

#### 🎯 What
Removed redundant `if (cursor >= size) break;` statements in `LZ77Decompressor::decompress` within `src/core/compression/LZ77.cpp`.

#### 💡 Why
These statements were dead code. They were located inside loops whose conditions (`while (cursor < size)` and `for (... && cursor < size; ...)`) already guaranteed that `cursor < size` when entering the loop body. Removing them improves code readability and maintainability.

#### ✅ Verification
- Compiled and executed `tests/test_compression_lz77.cpp` using a standalone harness.
- All test suites passed:
  - `[UNIT]` tests (basic functionality)
  - `[EDGE]` case tests (truncated inputs)
  - `[PROP]` property tests (round-trip integrity with random patterns)
  - `[FUZZ]` tests (robustness against random garbage)

#### ✨ Result
Improved codebase health by eliminating unreachable code and simplifying the decompression logic.

---
*PR created automatically by Jules for task [5308974876308980261](https://jules.google.com/task/5308974876308980261) started by @segin*