### PR TITLE
🧪 [testing improvement: invalid EXTINF duration parsing]

### DIFF
--- a/tests/test_playlist_load.cpp
+++ b/tests/test_playlist_load.cpp
@@ -29,6 +29,7 @@ protected:
         testLoadPlaylistWithComments();
         testResolveInlineSourcesPreservesOrder();
         testResolveInlineSourcesRecursesNestedPlaylists();
+        testLoadPlaylistWithInvalidDuration();
     }
 
 private:
@@ -174,6 +175,23 @@ private:
 
         std::remove(inner_playlist.c_str());
         std::remove(outer_playlist.c_str());
+    }
+
+    void testLoadPlaylistWithInvalidDuration() {
+        std::string content = "#EXTM3U\n#EXTINF:invalid_duration,Artist Name - Song Title\n/path/to/song.mp3\n";
+        std::string filename = createTempM3U(content, "temp_invalid_duration.m3u");
+
+        auto playlist = Playlist::loadPlaylist(TagLib::String(filename, TagLib::String::UTF8));
+
+        ASSERT_NOT_NULL(playlist.get(), "Playlist should not be null");
+        ASSERT_EQUALS(1, playlist->entries(), "Playlist should have 1 entry");
+
+        const track* t = playlist->getTrackInfo(0);
+        ASSERT_NOT_NULL(t, "Track info should not be null");
+
+        ASSERT_EQUALS(0u, t->GetLen(), "Duration should be 0 for invalid EXTINF duration");
+
+        std::remove(filename.c_str());
     }
 };
 


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing validation for malformed duration strings in M3U `#EXTINF` tags.
📊 **Coverage:** This PR adds a unit test to `tests/test_playlist_load.cpp` that specifically targets the `try-catch` block in `src/playlist.cpp` responsible for parsing track durations. It verifies that the loader defaults to 0 when parsing non-numeric strings.
✨ **Result:** Increased test coverage for the playlist loader and ensured robust handling of invalid metadata in playlist files.

---
*PR created automatically by Jules for task [6251494046040014092](https://jules.google.com/task/6251494046040014092) started by @segin*